### PR TITLE
Add grid_search

### DIFF
--- a/pyswarms/single/local_best.py
+++ b/pyswarms/single/local_best.py
@@ -110,7 +110,7 @@ class LocalBestPSO(SwarmBase):
             a tuple of size 2 where the first entry is the minimum velocity
             and the second entry is the maximum velocity. It 
             sets the limits for velocity clamping. 
-        options : dict with keys :code:`{'c1', 'c2', 'k', 'p'}`
+        options : dict with keys :code:`{'c1', 'c2', 'w', 'k', 'p'}`
             a dictionary containing the parameters for the specific 
             optimization technique
                 * c1 : float

--- a/pyswarms/utils/search/grid_search.py
+++ b/pyswarms/utils/search/grid_search.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+
+"""
+Hyperparameter grid search.
+
+Compares the relative performance of hyperparameter value combinations in
+reducing a specified objective function.
+
+For each hyperparameter, user can provide either a single value or a list
+of possible values, and their cartesian product is taken to produce a grid
+of all possible combinations. These combinations are then tested to produce
+a list of objective function scores. The default of the optimize method
+returns the hyperparameters that yield the minimum score, yet maximum score
+can also be evaluated.
+
+Parameters
+----------
+* c1 : float
+    cognitive parameter
+* c2 : float
+    social parameter
+* w : float
+    inertia parameter
+* k : int
+    number of neighbors to be considered. Must be a
+    positive integer less than `n_particles`
+* p: int {1,2}
+    the Minkowski p-norm to use. 1 is the
+    sum-of-absolute values (or L1 distance) while 2 is
+    the Euclidean (or L2) distance.
+
+>>> options = {'c1': [1, 2, 3],
+               'c2': [1, 2, 3],
+               'w' : [2, 3, 5],
+               'k' : [5, 10, 15],
+               'p' : 1}
+>>> g = GridSearch(LocalBestPSO, n_particles=40, dimensions=20,
+                   options=options, objective_func=sphere_func, iters=10)
+>>> best_score, best_options = g.optimize()
+>>> best_score
+301.418815268
+>>> best_options['c1']
+1
+>>> best_options['c2']
+1
+"""
+
+import operator as op
+import itertools
+import numpy as np
+
+class GridSearch(object):
+    """Exhaustive search of optimal performance on selected objective function
+    over all combinations of specified hyperparameter values."""
+
+    def __init__(self, optimizer, n_particles, dimensions, options,
+                 objective_func, iters, bounds=None, velocity_clamp=None):
+        """Initializes the GridSearch.
+
+        Attributes
+        ----------
+        optimizer: PySwarms class
+            either LocalBestPSO or GlobalBestPSO
+        n_particles : int
+            number of particles in the swarm.
+        dimensions : int
+            number of dimensions in the space.
+        options : dict with keys :code:`{'c1', 'c2', 'w', 'k', 'p'}`
+            a dictionary containing the parameters for the specific
+            optimization technique
+                * c1 : float
+                    cognitive parameter
+                * c2 : float
+                    social parameter
+                * w : float
+                    inertia parameter
+                * k : int
+                    number of neighbors to be considered. Must be a
+                    positive integer less than :code:`n_particles`
+                * p: int {1,2}
+                    the Minkowski p-norm to use. 1 is the
+                    sum-of-absolute values (or L1 distance) while 2 is
+                    the Euclidean (or L2) distance.
+        objective_func: function
+            objective function to be evaluated
+        iters: int
+            number of iterations
+        bounds : tuple of np.ndarray, optional (default is None)
+            a tuple of size 2 where the first entry is the minimum bound
+            while the second entry is the maximum bound. Each array must
+            be of shape :code:`(dimensions,)`.
+        velocity_clamp : tuple (default is :code:`None`)
+            a tuple of size 2 where the first entry is the minimum velocity
+            and the second entry is the maximum velocity. It
+            sets the limits for velocity clamping.
+        """
+
+        # Assign attributes
+        self.optimizer = optimizer
+        self.n_particles = n_particles
+        self.dims = dimensions
+        self.options = options
+        self.bounds = bounds
+        self.vclamp = velocity_clamp
+        self.objective_func = objective_func
+        self.iters = iters
+
+    def generate_grid(self):
+        """Generates the grid of all hyperparameter value combinations."""
+
+        #Extract keys and values from options dictionary
+        params = self.options.keys()
+        items = [x if type(x) == list \
+                 else [x] for x in list(zip(*self.options.items()))[1]]
+
+        #Create list of cartesian products of hyperparameter values from options
+        list_of_products = list(itertools.product(*items))
+
+        #Return list of dicts for all hyperparameter value combinations
+        return [dict(zip(*[params, list(x)])) for x in list_of_products]
+
+    def generate_score(self, options):
+        """Generates score for optimizer's performance on objective function."""
+
+        #Intialize optimizer
+        f = self.optimizer(self.n_particles, self.dims, options,
+                        self.bounds, self.vclamp)
+
+        #Return score
+        return f.optimize(self.objective_func, self.iters)[0]
+
+    def search(self, maximum=False):
+        """Compares optimizer's objective function performance scores
+        for all combinations of provided parameters."""
+
+        #Assign parameter keys
+        params = self.options.keys()
+
+        #Generate the grid of all hyperparameter value combinations
+        grid = self.generate_grid()
+
+        #Calculate scores for all hyperparameter combinations
+        scores = [self.generate_score(i) for i in grid]
+
+        #Select optimization function
+        if maximum:
+            idx, self.best_score = max(enumerate(scores), key=op.itemgetter(1))
+        else:
+            idx, self.best_score = min(enumerate(scores), key=op.itemgetter(1))
+
+        #Return optimum hyperparameter value property from grid using index
+        self.best_options = op.itemgetter(idx)(grid)
+        return self.best_score, self.best_options

--- a/tests/utils/search/test_gridsearch.py
+++ b/tests/utils/search/test_gridsearch.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Unit testing for pyswarms.grid_search"""
+
+# Import modules
+import unittest
+import numpy as np
+
+from pyswarms.utils.search.grid_search import GridSearch
+from pyswarms.single import LocalBestPSO
+from pyswarms.single import GlobalBestPSO
+from pyswarms.utils.functions.single_obj import sphere_func
+
+class TestGridSearch(unittest.TestCase):
+
+    def setUp(self):
+        """Sets up test fixtures"""
+        self.optimizer = LocalBestPSO
+        self.n_particles = 40
+        self.dimensions = 20
+        self.options = {'c1': [1, 2, 3],
+                        'c2': [1, 2, 3],
+                        'k' : [5, 10, 15],
+                        'w' : [0.9, 0.7, 0.4],
+                        'p' : [1]}
+        self.bounds = (np.array([-5,-5]), np.array([5,5]))
+        self.iters = 10
+        self.objective_func = sphere_func
+
+    def test_optimize(self):
+        """Tests if the optimize method returns expected values."""
+        g = GridSearch(self.optimizer, self.n_particles, self.dimensions,
+                       self.options, self.objective_func, self.iters,
+                       bounds=None, velocity_clamp=None)
+
+        minimum_best_score, minimum_best_options = g.search()
+        maximum_best_score, maximum_best_options = g.search(maximum=True)
+
+        # Test method returns a dict
+        self.assertEqual(type(minimum_best_options), dict)
+        self.assertEqual(type(maximum_best_options), dict)
+
+        # The scores could be equal, but for our test case the
+        # max score is greater than the min.
+        self.assertGreater(maximum_best_score, minimum_best_score)
+
+    def test_generate_grid(self):
+        """Tests if generate_grid function returns expected value."""
+        options = {'c1': [1,2],
+                   'c2': 6,
+                   'k': 5,
+                   'w': 0.9,
+                   'p': 0}
+        g = GridSearch(self.optimizer, self.n_particles, self.dimensions,
+                       options, self.objective_func, self.iters,
+                       bounds=None, velocity_clamp=None)
+        self.assertEqual(g.generate_grid(),
+                         [{'c1': 1, 'c2': 6, 'k': 5, 'w': 0.9, 'p': 0},
+                          {'c1': 2, 'c2': 6, 'k': 5, 'w': 0.9, 'p': 0}])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi LJ,

I put together a simple grid_search and test for the PSO parameter optimization. 

I'm thinking it might make sense to create a MockOptimizer() class to test the method directly, independent of the pyswarms optimizers, but wanted to get your thoughts on that before building it. 

Also, I'm not sure if it's confusing that I've required `objective_func` and `iters` to be set up front when creating the GridSearch instance, but I think this might be clearer than requiring them to be passed at the time of the optimize call. Let me know if you'd prefer the latter, and I can change that. 

Once we confirm this is on a good path, I can follow the same general approach to build the random_search, and then write up a Jupyter notebook showing them both in context. 

I look forward to hearing your thoughts!

Warmly,

Siobhán


