### PR TITLE
Test assertions in search (#27)

### DIFF
--- a/tests/utils/search/test_gridsearch.py
+++ b/tests/utils/search/test_gridsearch.py
@@ -71,7 +71,7 @@ class MethodReturnValues(Base):
                          [{'c1': 1, 'c2': 6, 'k': 5, 'w': 0.9, 'p': 0},
                           {'c1': 2, 'c2': 6, 'k': 5, 'w': 0.9, 'p': 0}])
 
-class Instantiate(Base):
+class Instantiation(Base):
 
     def test_optimizer_type_fail(self):
         """Tests that :code:`optimizer` of type :code:`string` raises

--- a/tests/utils/search/test_gridsearch.py
+++ b/tests/utils/search/test_gridsearch.py
@@ -57,7 +57,6 @@ class MethodReturnType(Base):
         maximum_best_score, maximum_best_options = self.g.search(maximum=True)
         self.assertIsInstance(maximum_best_options, dict)
 
-
 class MethodReturnValues(Base):
 
     def test_search_greater_values(self):
@@ -71,3 +70,14 @@ class MethodReturnValues(Base):
         self.assertEqual(self.g_mini.generate_grid(),
                          [{'c1': 1, 'c2': 6, 'k': 5, 'w': 0.9, 'p': 0},
                           {'c1': 2, 'c2': 6, 'k': 5, 'w': 0.9, 'p': 0}])
+
+class Instantiate(Base):
+
+    def test_optimizer_type_fail(self):
+        """Tests that :code:`optimizer` of type :code:`string` raises
+        :code:`TypeError`"""
+        bad_optimizer = 'LocalBestPSO'  # a string instead of a class object
+        with self.assertRaises(TypeError):
+            g = GridSearch(bad_optimizer, self.n_particles, self.dimensions,
+                           self.options, self.objective_func, self.iters,
+                           bounds=None, velocity_clamp=None)

--- a/tests/utils/search/test_randomsearch.py
+++ b/tests/utils/search/test_randomsearch.py
@@ -80,3 +80,24 @@ class MethodReturnValues(Base):
                 self.assertGreaterEqual(j, self.options[i][0])
                 self.assertLessEqual(j, self.options[i][1])
 
+class Instantiation(Base):
+
+    def test_optimizer_type_fail(self):
+        """Test that :code:`optimizer` of type :code:`string` raises
+        :code:`TypeError`"""
+        bad_optimizer = 'LocalBestPSO'  # a string instead of a class object
+        with self.assertRaises(TypeError):
+            g = RandomSearch(bad_optimizer, self.n_particles, self.dimensions,
+                             self.options, self.objective_func, self.iters,
+                             self.n_selection_iters, bounds=None,
+                             velocity_clamp=None)
+
+    def test_n_selection_iters_type_fail(self):
+        """Test that :code:`n_selection_iters` of type :code:`float` raises
+        :code:`TypeError`"""
+        bad_n_selection_iters = 100.0  # should be an int
+        with self.assertRaises(TypeError):
+            g = RandomSearch(self.optimizer, self.n_particles, self.dimensions,
+                             self.options, self.objective_func, self.iters,
+                             bad_n_selection_iters, self.bounds,
+                             velocity_clamp=None)


### PR DESCRIPTION
Tests that a bad type for the `optimizer` parameter to `GridSearch()` raises a `TypeError`.
Tests that a bad type for the `optimizer` parameter or the `n_selection_iters` parameter
    to `RandomSearch()` raises a `TypeError`.

Author: jazcap53
Email: andrew.jarcho@gmail.com