### PR TITLE
Add the possibility to set an initial starting point (a guess) and thetolerance acceptable on the objective cost function evaluation

### DIFF
--- a/pyswarms/single/global_best.py
+++ b/pyswarms/single/global_best.py
@@ -72,7 +72,7 @@ from ..utils.console_utils import cli_print, end_report
 class GlobalBestPSO(SwarmBase):
 
     def __init__(self, n_particles, dimensions, options,
-                 bounds=None, velocity_clamp=None):
+                 bounds=None, velocity_clamp=None, guess=None, ftol=-np.inf):
         """Initializes the swarm.
 
         Attributes
@@ -98,9 +98,15 @@ class GlobalBestPSO(SwarmBase):
             a tuple of size 2 where the first entry is the minimum velocity
             and the second entry is the maximum velocity. It
             sets the limits for velocity clamping.
+        guess : list (default is :code:`None`)
+            a list of size :code:`dimensions`
+        ftol : float
+            relative error in objective_func(best_pos) acceptable for
+            convergence
         """
         super(GlobalBestPSO, self).__init__(n_particles, dimensions, options,
-                                            bounds, velocity_clamp)
+                                            bounds, velocity_clamp,
+                                            guess, ftol)
 
         # Initialize logger
         self.logger = logging.getLogger(__name__)
@@ -166,6 +172,10 @@ class GlobalBestPSO(SwarmBase):
                 velocity=self.velocity
             )
             self._populate_history(hist)
+
+            # Verify stop criteria based on the relative acceptable cost ftol
+            if np.min(self.best_cost) < self.ftol:
+                break
 
             # Perform velocity and position updates
             self._update_velocity()

--- a/pyswarms/single/local_best.py
+++ b/pyswarms/single/local_best.py
@@ -106,7 +106,7 @@ class LocalBestPSO(SwarmBase):
                              'or 2 (for L2/Euclidean).')
 
     def __init__(self, n_particles, dimensions, options, bounds=None,
-                 velocity_clamp=None):
+                 velocity_clamp=None, guess=None, ftol=-np.inf):
         """Initializes the swarm.
 
         Attributes
@@ -123,6 +123,11 @@ class LocalBestPSO(SwarmBase):
             a tuple of size 2 where the first entry is the minimum velocity
             and the second entry is the maximum velocity. It
             sets the limits for velocity clamping.
+        guess : list (default is :code:`None`)
+            a list of size :code:`dimensions`
+        ftol : float
+            relative error in objective_func(best_pos) acceptable for
+            convergence
         options : dict with keys :code:`{'c1', 'c2', 'w', 'k', 'p'}`
             a dictionary containing the parameters for the specific
             optimization technique
@@ -146,7 +151,7 @@ class LocalBestPSO(SwarmBase):
         self.k, self.p = options['k'], options['p']
         # Initialize parent class
         super(LocalBestPSO, self).__init__(n_particles, dimensions, options,
-                                           bounds, velocity_clamp)
+                                           bounds, velocity_clamp, guess, ftol)
         # Invoke assertions
         self.assertions()
         # Initialize the resettable attributes
@@ -212,6 +217,9 @@ class LocalBestPSO(SwarmBase):
             )
             self._populate_history(hist)
 
+            # Verify stop criteria based on the relative acceptable cost ftol
+            if np.min(self.best_cost) < self.ftol:
+                break
             # Perform position velocity update
             self._update_velocity()
             self._update_position()

--- a/tests/optimizers/test_global_best.py
+++ b/tests/optimizers/test_global_best.py
@@ -69,7 +69,7 @@ class Instantiation(Base):
             optimizer = GlobalBestPSO(5,2,bounds=bounds_2,options=self.options)
 
     def test_bound_shapes_fail(self):
-        """Tests if exception is thrown when bounds are of unequal 
+        """Tests if exception is thrown when bounds are of unequal
         shapes."""
         bounds = (np.array([-5,-5,-5]), np.array([5,5]))
         with self.assertRaises(IndexError):
@@ -99,6 +99,18 @@ class Instantiation(Base):
         velocity_clamp = (3,2)
         with self.assertRaises(ValueError):
             optimizer = GlobalBestPSO(5,2,velocity_clamp=velocity_clamp,options=self.options)
+
+    def test_guess_type_fail(self):
+        """Tests if exception is thrown when guess is not a list."""
+        guess = (0.1,1.5)
+        with self.assertRaises(TypeError):
+            optimizer = GlobalBestPSO(5,2,guess=guess,options=self.options)
+    def test_guess_shape_fail(self):
+        """Tests if exception is thrown when guess dimension is not equal
+        to dimensions"""
+        guess = [1.5, 3.2, 2.5]
+        with self.assertRaises(IndexError):
+            optimizer = GlobalBestPSO(5,2,guess=guess,options=self.options)
 
 class MethodsStateChange(Base):
     """Tests all state changes that resulted from method calls"""
@@ -164,6 +176,15 @@ class RunOptimize(Base):
         self.optimizer.optimize(sphere_func, 1000, verbose=0)
         velocity_hist = self.optimizer.get_velocity_history
         self.assertEqual(velocity_hist.shape, (1000, 10, 2))
+
+    def test_ftol_effect(self):
+        """Check if setting ftol breaks the optimization process
+        accordingly."""
+        # Perform a simple optimization
+        optimizer = GlobalBestPSO(5,2, options=self.options, ftol=1e-1)
+        optimizer.optimize(sphere_func, 1000, verbose=0)
+        cost_hist = optimizer.get_cost_history
+        self.assertNotEqual(cost_hist.shape, (1000, ))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/optimizers/test_local_best.py
+++ b/tests/optimizers/test_local_best.py
@@ -76,7 +76,7 @@ class Instantiation(Base):
             optimizer = LocalBestPSO(5,2, bounds=bounds_2, options=self.options)
 
     def test_bound_shapes_fail(self):
-        """Tests if exception is thrown when bounds are of unequal 
+        """Tests if exception is thrown when bounds are of unequal
         shapes."""
         bounds = (np.array([-5,-5,-5]), np.array([5,5]))
         with self.assertRaises(IndexError):
@@ -122,6 +122,18 @@ class Instantiation(Base):
         velocity_clamp = (3,2)
         with self.assertRaises(ValueError):
             optimizer = LocalBestPSO(5,2,velocity_clamp=velocity_clamp, options=self.options)
+
+    def test_guess_type_fail(self):
+        """Tests if exception is thrown when guess is not a list."""
+        guess = (0.1,1.5)
+        with self.assertRaises(TypeError):
+            optimizer = LocalBestPSO(5,2,guess=guess,options=self.options)
+    def test_guess_shape_fail(self):
+        """Tests if exception is thrown when guess dimension is not equal
+        to dimensions"""
+        guess = [1.5, 3.2, 2.5]
+        with self.assertRaises(IndexError):
+            optimizer = LocalBestPSO(5,2,guess=guess,options=self.options)
 
 class MethodsStateChange(Base):
     """Tests all state changes that resulted from method calls"""
@@ -187,6 +199,15 @@ class RunOptimize(Base):
         self.optimizer.optimize(sphere_func, 1000, verbose=0)
         velocity_hist = self.optimizer.get_velocity_history
         self.assertEqual(velocity_hist.shape, (1000, 10, 2))
+
+    def test_ftol_effect(self):
+        """Check if setting ftol breaks the optimization process
+        accordingly."""
+        # Perform a simple optimization
+        optimizer = LocalBestPSO(5,2, options=self.options, ftol=1e-1)
+        optimizer.optimize(sphere_func, 2000, verbose=0)
+        cost_hist = optimizer.get_cost_history
+        self.assertNotEqual(cost_hist.shape, (2000, ))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I added two new features which are:
1. Provide the possibility for the user to set manually a starting point for both global and local PSO.
2. Provide the possibility for the user to specify manually a tolerance in the objective function evaluation.

These features are available for many optimization algorithms such as those used in the scipy optimize library. I think they are useful for instance when we want to compare PSO with Nelder-Mead (the version under scipy optimize), with those two attributes, we can set them on equal footing.