### PR TITLE
Add guess and acceptable tolerance of objective function evaluation features

### DIFF
--- a/pyswarms/base/base_single.py
+++ b/pyswarms/base/base_single.py
@@ -82,12 +82,12 @@ class SwarmBase(object):
                 raise ValueError('Make sure that velocity_clamp is in the '
                                  'form (min, max)')
 
-        # Check setting of guess
-        if self.guess is not None:
-            if not isinstance(self.guess, list):
-                raise TypeError('Parameter `guess` must be a list')
-            if not len(self.guess) == self.dimensions:
-                raise IndexError('Parameter `guess` must be the same shape '
+        # Check setting of init_pos
+        if self.init_pos is not None:
+            if not isinstance(self.init_pos, list):
+                raise TypeError('Parameter `init_pos` must be a list')
+            if not len(self.init_pos) == self.dimensions:
+                raise IndexError('Parameter `init_pos` must be the same shape '
                                  'as dimensions.')
 
         # Required keys in options argument
@@ -119,7 +119,7 @@ class SwarmBase(object):
             logging.basicConfig(level=default_level)
 
     def __init__(self, n_particles, dimensions, options,
-                 bounds=None, velocity_clamp=None, guess=None, ftol=-np.inf):
+                 bounds=None, velocity_clamp=None, init_pos=None, ftol=-np.inf):
         """Initializes the swarm.
 
         Creates a :code:`numpy.ndarray` of positions depending on the
@@ -150,7 +150,7 @@ class SwarmBase(object):
             a tuple of size 2 where the first entry is the minimum velocity
             and the second entry is the maximum velocity. It
             sets the limits for velocity clamping.
-        guess : list (default is :code:`None`)
+        init_pos : list (default is :code:`None`)
             a list of size :code:`dimensions`
         ftol : float
             relative error in objective_func(best_pos) acceptable for convergence
@@ -164,7 +164,7 @@ class SwarmBase(object):
         self.velocity_clamp = velocity_clamp
         self.swarm_size = (n_particles, dimensions)
         self.options = options
-        self.guess = guess
+        self.init_pos = init_pos
         self.ftol = ftol
         # Initialize named tuple for populating the history list
         self.ToHistory = namedtuple('ToHistory',
@@ -303,8 +303,8 @@ class SwarmBase(object):
             self.max_bounds = np.repeat(self.bounds[1][np.newaxis, :],
                                         self.n_particles,
                                         axis=0)
-            if self.guess is not None:
-                self.pos = self.guess * np.random.uniform(low=self.min_bounds,
+            if self.init_pos is not None:
+                self.pos = self.init_pos * np.random.uniform(low=self.min_bounds,
                                          high=self.max_bounds,
                                          size=self.swarm_size)
             else:
@@ -312,8 +312,8 @@ class SwarmBase(object):
                                          high=self.max_bounds,
                                          size=self.swarm_size)
         else:
-            if self.guess is not None:
-                self.pos = self.guess * np.random.uniform(size=self.swarm_size)
+            if self.init_pos is not None:
+                self.pos = self.init_pos * np.random.uniform(size=self.swarm_size)
             else:
                 self.pos = np.random.uniform(size=self.swarm_size)
 

--- a/pyswarms/base/base_single.py
+++ b/pyswarms/base/base_single.py
@@ -84,11 +84,14 @@ class SwarmBase(object):
 
         # Check setting of init_pos
         if self.init_pos is not None:
-            if not isinstance(self.init_pos, list):
-                raise TypeError('Parameter `init_pos` must be a list')
+            if not (isinstance(self.init_pos, list) or isinstance(self.init_pos, np.ndarray)):
+                raise TypeError('Parameter `init_pos` must be an array (list or numpy array)')
             if not len(self.init_pos) == self.dimensions:
                 raise IndexError('Parameter `init_pos` must be the same shape '
                                  'as dimensions.')
+            if isinstance(self.init_pos, np.ndarray) and self.init_pos.ndim != 1:
+                raise ValueError('Parameter `init_pos` must have a 1d array')
+
 
         # Required keys in options argument
         if not all(key in self.options for key in ('c1', 'c2', 'w')):
@@ -151,7 +154,7 @@ class SwarmBase(object):
             and the second entry is the maximum velocity. It
             sets the limits for velocity clamping.
         init_pos : list (default is :code:`None`)
-            a list of size :code:`dimensions`
+            an array of size :code:`dimensions`
         ftol : float
             relative error in objective_func(best_pos) acceptable for convergence
 

--- a/pyswarms/single/global_best.py
+++ b/pyswarms/single/global_best.py
@@ -72,7 +72,7 @@ from ..utils.console_utils import cli_print, end_report
 class GlobalBestPSO(SwarmBase):
 
     def __init__(self, n_particles, dimensions, options,
-                 bounds=None, velocity_clamp=None, guess=None, ftol=-np.inf):
+                 bounds=None, velocity_clamp=None, init_pos=None, ftol=-np.inf):
         """Initializes the swarm.
 
         Attributes
@@ -98,7 +98,7 @@ class GlobalBestPSO(SwarmBase):
             a tuple of size 2 where the first entry is the minimum velocity
             and the second entry is the maximum velocity. It
             sets the limits for velocity clamping.
-        guess : list (default is :code:`None`)
+        init_pos : list (default is :code:`None`)
             a list of size :code:`dimensions`
         ftol : float
             relative error in objective_func(best_pos) acceptable for
@@ -106,7 +106,7 @@ class GlobalBestPSO(SwarmBase):
         """
         super(GlobalBestPSO, self).__init__(n_particles, dimensions, options,
                                             bounds, velocity_clamp,
-                                            guess, ftol)
+                                            init_pos, ftol)
 
         # Initialize logger
         self.logger = logging.getLogger(__name__)

--- a/pyswarms/single/global_best.py
+++ b/pyswarms/single/global_best.py
@@ -72,7 +72,7 @@ from ..utils.console_utils import cli_print, end_report
 class GlobalBestPSO(SwarmBase):
 
     def __init__(self, n_particles, dimensions, options,
-                 bounds=None, velocity_clamp=None):
+                 bounds=None, velocity_clamp=None, guess=None, ftol=-np.inf):
         """Initializes the swarm.
 
         Attributes
@@ -98,9 +98,15 @@ class GlobalBestPSO(SwarmBase):
             a tuple of size 2 where the first entry is the minimum velocity
             and the second entry is the maximum velocity. It
             sets the limits for velocity clamping.
+        guess : list (default is :code:`None`)
+            a list of size :code:`dimensions`
+        ftol : float
+            relative error in objective_func(best_pos) acceptable for
+            convergence
         """
         super(GlobalBestPSO, self).__init__(n_particles, dimensions, options,
-                                            bounds, velocity_clamp)
+                                            bounds, velocity_clamp,
+                                            guess, ftol)
 
         # Initialize logger
         self.logger = logging.getLogger(__name__)
@@ -166,6 +172,10 @@ class GlobalBestPSO(SwarmBase):
                 velocity=self.velocity
             )
             self._populate_history(hist)
+
+            # Verify stop criteria based on the relative acceptable cost ftol
+            if np.min(self.best_cost) < self.ftol:
+                break
 
             # Perform velocity and position updates
             self._update_velocity()

--- a/pyswarms/single/global_best.py
+++ b/pyswarms/single/global_best.py
@@ -99,7 +99,7 @@ class GlobalBestPSO(SwarmBase):
             and the second entry is the maximum velocity. It
             sets the limits for velocity clamping.
         init_pos : list (default is :code:`None`)
-            a list of size :code:`dimensions`
+            an array of size :code:`dimensions`
         ftol : float
             relative error in objective_func(best_pos) acceptable for
             convergence

--- a/pyswarms/single/local_best.py
+++ b/pyswarms/single/local_best.py
@@ -106,7 +106,7 @@ class LocalBestPSO(SwarmBase):
                              'or 2 (for L2/Euclidean).')
 
     def __init__(self, n_particles, dimensions, options, bounds=None,
-                 velocity_clamp=None, guess=None, ftol=-np.inf):
+                 velocity_clamp=None, init_pos=None, ftol=-np.inf):
         """Initializes the swarm.
 
         Attributes
@@ -123,7 +123,7 @@ class LocalBestPSO(SwarmBase):
             a tuple of size 2 where the first entry is the minimum velocity
             and the second entry is the maximum velocity. It
             sets the limits for velocity clamping.
-        guess : list (default is :code:`None`)
+        init_pos : list (default is :code:`None`)
             a list of size :code:`dimensions`
         ftol : float
             relative error in objective_func(best_pos) acceptable for
@@ -151,7 +151,7 @@ class LocalBestPSO(SwarmBase):
         self.k, self.p = options['k'], options['p']
         # Initialize parent class
         super(LocalBestPSO, self).__init__(n_particles, dimensions, options,
-                                           bounds, velocity_clamp, guess, ftol)
+                                           bounds, velocity_clamp, init_pos, ftol)
         # Invoke assertions
         self.assertions()
         # Initialize the resettable attributes

--- a/pyswarms/single/local_best.py
+++ b/pyswarms/single/local_best.py
@@ -124,7 +124,7 @@ class LocalBestPSO(SwarmBase):
             and the second entry is the maximum velocity. It
             sets the limits for velocity clamping.
         init_pos : list (default is :code:`None`)
-            a list of size :code:`dimensions`
+            an array of size :code:`dimensions`
         ftol : float
             relative error in objective_func(best_pos) acceptable for
             convergence

--- a/pyswarms/single/local_best.py
+++ b/pyswarms/single/local_best.py
@@ -106,7 +106,7 @@ class LocalBestPSO(SwarmBase):
                              'or 2 (for L2/Euclidean).')
 
     def __init__(self, n_particles, dimensions, options, bounds=None,
-                 velocity_clamp=None):
+                 velocity_clamp=None, guess=None, ftol=-np.inf):
         """Initializes the swarm.
 
         Attributes
@@ -123,6 +123,11 @@ class LocalBestPSO(SwarmBase):
             a tuple of size 2 where the first entry is the minimum velocity
             and the second entry is the maximum velocity. It
             sets the limits for velocity clamping.
+        guess : list (default is :code:`None`)
+            a list of size :code:`dimensions`
+        ftol : float
+            relative error in objective_func(best_pos) acceptable for
+            convergence
         options : dict with keys :code:`{'c1', 'c2', 'w', 'k', 'p'}`
             a dictionary containing the parameters for the specific
             optimization technique
@@ -146,7 +151,7 @@ class LocalBestPSO(SwarmBase):
         self.k, self.p = options['k'], options['p']
         # Initialize parent class
         super(LocalBestPSO, self).__init__(n_particles, dimensions, options,
-                                           bounds, velocity_clamp)
+                                           bounds, velocity_clamp, guess, ftol)
         # Invoke assertions
         self.assertions()
         # Initialize the resettable attributes
@@ -212,6 +217,9 @@ class LocalBestPSO(SwarmBase):
             )
             self._populate_history(hist)
 
+            # Verify stop criteria based on the relative acceptable cost ftol
+            if np.min(self.best_cost) < self.ftol:
+                break
             # Perform position velocity update
             self._update_velocity()
             self._update_position()

--- a/tests/optimizers/test_global_best.py
+++ b/tests/optimizers/test_global_best.py
@@ -100,17 +100,18 @@ class Instantiation(Base):
         with self.assertRaises(ValueError):
             optimizer = GlobalBestPSO(5,2,velocity_clamp=velocity_clamp,options=self.options)
 
-    def test_guess_type_fail(self):
-        """Tests if exception is thrown when guess is not a list."""
-        guess = (0.1,1.5)
+    def test_init_pos_type_fail(self):
+        """Tests if exception is thrown when init_pos is not a list."""
+        init_pos = (0.1,1.5)
         with self.assertRaises(TypeError):
-            optimizer = GlobalBestPSO(5,2,guess=guess,options=self.options)
-    def test_guess_shape_fail(self):
-        """Tests if exception is thrown when guess dimension is not equal
+            optimizer = GlobalBestPSO(5, 2, init_pos=init_pos, options=self.options)
+
+    def test_init_pos_shape_fail(self):
+        """Tests if exception is thrown when init_pos dimension is not equal
         to dimensions"""
-        guess = [1.5, 3.2, 2.5]
+        init_pos = [1.5, 3.2, 2.5]
         with self.assertRaises(IndexError):
-            optimizer = GlobalBestPSO(5,2,guess=guess,options=self.options)
+            optimizer = GlobalBestPSO(5, 2, init_pos=init_pos, options=self.options)
 
 class MethodsStateChange(Base):
     """Tests all state changes that resulted from method calls"""

--- a/tests/optimizers/test_global_best.py
+++ b/tests/optimizers/test_global_best.py
@@ -182,9 +182,9 @@ class RunOptimize(Base):
         accordingly."""
         # Perform a simple optimization
         optimizer = GlobalBestPSO(5,2, options=self.options, ftol=1e-1)
-        optimizer.optimize(sphere_func, 1000, verbose=0)
+        optimizer.optimize(sphere_func, 2000, verbose=0)
         cost_hist = optimizer.get_cost_history
-        self.assertNotEqual(cost_hist.shape, (1000, ))
+        self.assertNotEqual(cost_hist.shape, (2000, ))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/optimizers/test_global_best.py
+++ b/tests/optimizers/test_global_best.py
@@ -182,7 +182,7 @@ class RunOptimize(Base):
         """Check if setting ftol breaks the optimization process
         accordingly."""
         # Perform a simple optimization
-        optimizer = GlobalBestPSO(5,2, options=self.options, ftol=1e-1)
+        optimizer = GlobalBestPSO(10,2, options=self.options, ftol=1e-1)
         optimizer.optimize(sphere_func, 2000, verbose=0)
         cost_hist = optimizer.get_cost_history
         self.assertNotEqual(cost_hist.shape, (2000, ))

--- a/tests/optimizers/test_global_best.py
+++ b/tests/optimizers/test_global_best.py
@@ -181,7 +181,7 @@ class RunOptimize(Base):
         """Check if setting ftol breaks the optimization process
         accordingly."""
         # Perform a simple optimization
-        optimizer = GlobalBestPSO(5,2, options=self.options, ftol=1e-1)
+        optimizer = GlobalBestPSO(10,2, options=self.options, ftol=1e-1)
         optimizer.optimize(sphere_func, 2000, verbose=0)
         cost_hist = optimizer.get_cost_history
         self.assertNotEqual(cost_hist.shape, (2000, ))

--- a/tests/optimizers/test_global_best.py
+++ b/tests/optimizers/test_global_best.py
@@ -69,7 +69,7 @@ class Instantiation(Base):
             optimizer = GlobalBestPSO(5,2,bounds=bounds_2,options=self.options)
 
     def test_bound_shapes_fail(self):
-        """Tests if exception is thrown when bounds are of unequal 
+        """Tests if exception is thrown when bounds are of unequal
         shapes."""
         bounds = (np.array([-5,-5,-5]), np.array([5,5]))
         with self.assertRaises(IndexError):
@@ -99,6 +99,18 @@ class Instantiation(Base):
         velocity_clamp = (3,2)
         with self.assertRaises(ValueError):
             optimizer = GlobalBestPSO(5,2,velocity_clamp=velocity_clamp,options=self.options)
+
+    def test_guess_type_fail(self):
+        """Tests if exception is thrown when guess is not a list."""
+        guess = (0.1,1.5)
+        with self.assertRaises(TypeError):
+            optimizer = GlobalBestPSO(5,2,guess=guess,options=self.options)
+    def test_guess_shape_fail(self):
+        """Tests if exception is thrown when guess dimension is not equal
+        to dimensions"""
+        guess = [1.5, 3.2, 2.5]
+        with self.assertRaises(IndexError):
+            optimizer = GlobalBestPSO(5,2,guess=guess,options=self.options)
 
 class MethodsStateChange(Base):
     """Tests all state changes that resulted from method calls"""
@@ -164,6 +176,15 @@ class RunOptimize(Base):
         self.optimizer.optimize(sphere_func, 1000, verbose=0)
         velocity_hist = self.optimizer.get_velocity_history
         self.assertEqual(velocity_hist.shape, (1000, 10, 2))
+
+    def test_ftol_effect(self):
+        """Check if setting ftol breaks the optimization process
+        accordingly."""
+        # Perform a simple optimization
+        optimizer = GlobalBestPSO(5,2, options=self.options, ftol=1e-1)
+        optimizer.optimize(sphere_func, 1000, verbose=0)
+        cost_hist = optimizer.get_cost_history
+        self.assertNotEqual(cost_hist.shape, (1000, ))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/optimizers/test_global_best.py
+++ b/tests/optimizers/test_global_best.py
@@ -182,7 +182,7 @@ class RunOptimize(Base):
         """Check if setting ftol breaks the optimization process
         accordingly."""
         # Perform a simple optimization
-        optimizer = GlobalBestPSO(10,2, options=self.options, ftol=1e-1)
+        optimizer = GlobalBestPSO(5,2, options=self.options, ftol=1e-1)
         optimizer.optimize(sphere_func, 2000, verbose=0)
         cost_hist = optimizer.get_cost_history
         self.assertNotEqual(cost_hist.shape, (2000, ))

--- a/tests/optimizers/test_local_best.py
+++ b/tests/optimizers/test_local_best.py
@@ -123,17 +123,18 @@ class Instantiation(Base):
         with self.assertRaises(ValueError):
             optimizer = LocalBestPSO(5,2,velocity_clamp=velocity_clamp, options=self.options)
 
-    def test_guess_type_fail(self):
-        """Tests if exception is thrown when guess is not a list."""
-        guess = (0.1,1.5)
+    def test_init_pos_type_fail(self):
+        """Tests if exception is thrown when init_pos is not a list."""
+        init_pos = (0.1,1.5)
         with self.assertRaises(TypeError):
-            optimizer = LocalBestPSO(5,2,guess=guess,options=self.options)
-    def test_guess_shape_fail(self):
-        """Tests if exception is thrown when guess dimension is not equal
+            optimizer = LocalBestPSO(5, 2, init_pos=init_pos, options=self.options)
+
+    def test_init_pos_shape_fail(self):
+        """Tests if exception is thrown when init_pos dimension is not equal
         to dimensions"""
-        guess = [1.5, 3.2, 2.5]
+        init_pos = [1.5, 3.2, 2.5]
         with self.assertRaises(IndexError):
-            optimizer = LocalBestPSO(5,2,guess=guess,options=self.options)
+            optimizer = LocalBestPSO(5, 2, init_pos=init_pos, options=self.options)
 
 class MethodsStateChange(Base):
     """Tests all state changes that resulted from method calls"""

--- a/tests/optimizers/test_local_best.py
+++ b/tests/optimizers/test_local_best.py
@@ -205,9 +205,9 @@ class RunOptimize(Base):
         accordingly."""
         # Perform a simple optimization
         optimizer = LocalBestPSO(5,2, options=self.options, ftol=1e-1)
-        optimizer.optimize(sphere_func, 2000, verbose=0)
+        optimizer.optimize(sphere_func, 4000, verbose=0)
         cost_hist = optimizer.get_cost_history
-        self.assertNotEqual(cost_hist.shape, (2000, ))
+        self.assertNotEqual(cost_hist.shape, (4000, ))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/optimizers/test_local_best.py
+++ b/tests/optimizers/test_local_best.py
@@ -204,10 +204,10 @@ class RunOptimize(Base):
         """Check if setting ftol breaks the optimization process
         accordingly."""
         # Perform a simple optimization
-        optimizer = LocalBestPSO(5,2, options=self.options, ftol=1e-1)
-        optimizer.optimize(sphere_func, 5000, verbose=0)
+        optimizer = LocalBestPSO(10,2, options=self.options, ftol=1e-1)
+        optimizer.optimize(sphere_func, 2000, verbose=0)
         cost_hist = optimizer.get_cost_history
-        self.assertNotEqual(cost_hist.shape, (5000, ))
+        self.assertNotEqual(cost_hist.shape, (2000, ))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/optimizers/test_local_best.py
+++ b/tests/optimizers/test_local_best.py
@@ -205,7 +205,7 @@ class RunOptimize(Base):
         """Check if setting ftol breaks the optimization process
         accordingly."""
         # Perform a simple optimization
-        optimizer = LocalBestPSO(5,2, options=self.options, ftol=1e-1)
+        optimizer = LocalBestPSO(10,2, options=self.options, ftol=1e-1)
         optimizer.optimize(sphere_func, 5000, verbose=0)
         cost_hist = optimizer.get_cost_history
         self.assertNotEqual(cost_hist.shape, (5000, ))

--- a/tests/optimizers/test_local_best.py
+++ b/tests/optimizers/test_local_best.py
@@ -205,10 +205,10 @@ class RunOptimize(Base):
         """Check if setting ftol breaks the optimization process
         accordingly."""
         # Perform a simple optimization
-        optimizer = LocalBestPSO(10,2, options=self.options, ftol=1e-1)
-        optimizer.optimize(sphere_func, 2000, verbose=0)
+        optimizer = LocalBestPSO(5,2, options=self.options, ftol=1e-1)
+        optimizer.optimize(sphere_func, 5000, verbose=0)
         cost_hist = optimizer.get_cost_history
-        self.assertNotEqual(cost_hist.shape, (2000, ))
+        self.assertNotEqual(cost_hist.shape, (5000, ))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/optimizers/test_local_best.py
+++ b/tests/optimizers/test_local_best.py
@@ -76,7 +76,7 @@ class Instantiation(Base):
             optimizer = LocalBestPSO(5,2, bounds=bounds_2, options=self.options)
 
     def test_bound_shapes_fail(self):
-        """Tests if exception is thrown when bounds are of unequal 
+        """Tests if exception is thrown when bounds are of unequal
         shapes."""
         bounds = (np.array([-5,-5,-5]), np.array([5,5]))
         with self.assertRaises(IndexError):
@@ -122,6 +122,18 @@ class Instantiation(Base):
         velocity_clamp = (3,2)
         with self.assertRaises(ValueError):
             optimizer = LocalBestPSO(5,2,velocity_clamp=velocity_clamp, options=self.options)
+
+    def test_guess_type_fail(self):
+        """Tests if exception is thrown when guess is not a list."""
+        guess = (0.1,1.5)
+        with self.assertRaises(TypeError):
+            optimizer = LocalBestPSO(5,2,guess=guess,options=self.options)
+    def test_guess_shape_fail(self):
+        """Tests if exception is thrown when guess dimension is not equal
+        to dimensions"""
+        guess = [1.5, 3.2, 2.5]
+        with self.assertRaises(IndexError):
+            optimizer = LocalBestPSO(5,2,guess=guess,options=self.options)
 
 class MethodsStateChange(Base):
     """Tests all state changes that resulted from method calls"""
@@ -187,6 +199,15 @@ class RunOptimize(Base):
         self.optimizer.optimize(sphere_func, 1000, verbose=0)
         velocity_hist = self.optimizer.get_velocity_history
         self.assertEqual(velocity_hist.shape, (1000, 10, 2))
+
+    def test_ftol_effect(self):
+        """Check if setting ftol breaks the optimization process
+        accordingly."""
+        # Perform a simple optimization
+        optimizer = LocalBestPSO(5,2, options=self.options, ftol=1e-1)
+        optimizer.optimize(sphere_func, 2000, verbose=0)
+        cost_hist = optimizer.get_cost_history
+        self.assertNotEqual(cost_hist.shape, (2000, ))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/optimizers/test_local_best.py
+++ b/tests/optimizers/test_local_best.py
@@ -205,9 +205,9 @@ class RunOptimize(Base):
         accordingly."""
         # Perform a simple optimization
         optimizer = LocalBestPSO(5,2, options=self.options, ftol=1e-1)
-        optimizer.optimize(sphere_func, 4000, verbose=0)
+        optimizer.optimize(sphere_func, 5000, verbose=0)
         cost_hist = optimizer.get_cost_history
-        self.assertNotEqual(cost_hist.shape, (4000, ))
+        self.assertNotEqual(cost_hist.shape, (5000, ))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
 Added two new features which are:

1. Provide the possibility for the user to set manually a starting point for both global and local PSO.
2. Provide the possibility for the user to specify manually a tolerance in the objective function evaluation.

These features are available for many optimization algorithms such as those used in the scipy optimize library. I think they are useful for instance when we want to compare PSO with Nelder-Mead (the version under scipy optimize), with those two attributes, we can set them on equal footing.

Note: Had to close my last PR because it does not pass the travis test, due to the test of tolerance feature. The behavior is normal since I am doing a simple test (in fact I am betting on Local PSO to finish before the maximum iteration which is not guaranteed) on the fact that the optimizer would finish before the maximum number of iteration, but somehow it failed. 