### PR TITLE
Revert pyyaml version change from 3.12 to 4.1

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,7 +8,7 @@ tox==3.0.0
 coverage==4.5.1
 Sphinx==1.7.5
 cryptography==2.2.2
-PyYAML==4.1
+PyYAML==3.12
 future==0.16.0
 scipy>=0.17.0
 numpy>=1.13.0


### PR DESCRIPTION
The change caused build errors in ReadTheDocs. Turns out that
the new change (without changelog even) is not yet present in
the PyPI servers.

Signed-off-by: Lester James V. Miranda <ljvmiranda@gmail.com>