### PR TITLE
Add static/dynamic functionality for topologies

### DIFF
--- a/pyswarms/backend/topology/base.py
+++ b/pyswarms/backend/topology/base.py
@@ -12,11 +12,30 @@ In addition, this class must interface with any class found in the
 :mod:`pyswarms.backend.swarms.Swarm` module.
 """
 
+# Import from stdlib
+import logging
+
+# Import from package
+from ...utils.console_utils import cli_print
+
 
 class Topology(object):
-    def __init__(self, **kwargs):
+    def __init__(self, static, **kwargs):
         """Initializes the class"""
-        pass
+
+        # Initialize logger
+        self.logger = logging.getLogger(__name__)
+
+        # Initialize attributes
+        self.static = static
+        self.neighbor_idx = None
+
+        if self.static:
+            cli_print("Running on `dynamic` topology, neighbors are updated regularly."
+                      "Set `static=True` for fixed neighbors.",
+                      1,
+                      0,
+                      self.logger)
 
     def compute_gbest(self, swarm):
         """Computes the best particle of the swarm and returns the cost and

--- a/pyswarms/backend/topology/pyramid.py
+++ b/pyswarms/backend/topology/pyramid.py
@@ -22,8 +22,16 @@ logger = logging.getLogger(__name__)
 
 
 class Pyramid(Topology):
-    def __init__(self):
-        super(Pyramid, self).__init__()
+    def __init__(self, static=False):
+        """Initialize the class
+
+        Parameters
+        ----------
+        static : bool (Default is :code:`False`)
+            a boolean that decides whether the topology
+            is static or dynamic
+        """
+        super(Pyramid, self).__init__(static)
 
     def compute_gbest(self, swarm):
         """Updates the global best using a pyramid neighborhood approach
@@ -49,12 +57,21 @@ class Pyramid(Topology):
                 best_pos = swarm.pbest_pos[np.argmin(swarm.pbest_cost)]
                 best_cost = np.min(swarm.pbest_cost)
             else:
-                pyramid = Delaunay(swarm.position)
-                indices, index_pointer = pyramid.vertex_neighbor_vertices
-                # Insert all the neighbors for each particle in the idx array
-                idx = np.array([index_pointer[indices[i]:indices[i+1]] for i in range(swarm.n_particles)])
-                idx_min = np.array([swarm.pbest_cost[idx[i]].argmin() for i in range(idx.size)])
-                best_neighbor = np.array([idx[i][idx_min[i]] for i in range(len(idx))]).astype(int)
+                # Check if the topology is static or dynamic and assign neighbors
+                if (self.static and self.neighbor_idx is None) or not self.static:
+                    pyramid = Delaunay(swarm.position)
+                    indices, index_pointer = pyramid.vertex_neighbor_vertices
+                    # Insert all the neighbors for each particle in the idx array
+                    self.neighbor_idx = np.array(
+                        [index_pointer[indices[i]:indices[i + 1]] for i in range(swarm.n_particles)]
+                    )
+
+                idx_min = np.array(
+                    [swarm.pbest_cost[self.neighbor_idx[i]].argmin() for i in range(len(self.neighbor_idx))]
+                )
+                best_neighbor = np.array(
+                    [self.neighbor_idx[i][idx_min[i]] for i in range(len(self.neighbor_idx))]
+                ).astype(int)
 
                 # Obtain best cost and position
                 best_cost = np.min(swarm.pbest_cost[best_neighbor])
@@ -86,7 +103,7 @@ class Pyramid(Topology):
             from pyswarms.backend.topology import Pyramid
 
             my_swarm = P.create_swarm(n_particles, dimensions)
-            my_topology = Pyramid()
+            my_topology = Pyramid(static=False)
 
             for i in range(iters):
                 # Inside the for-loop

--- a/pyswarms/backend/topology/star.py
+++ b/pyswarms/backend/topology/star.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 class Star(Topology):
     def __init__(self):
-        super(Star, self).__init__()
+        super(Star, self).__init__(static=False)
 
     def compute_gbest(self, swarm):
         """Obtains the global best cost and position based on a star topology
@@ -60,6 +60,7 @@ class Star(Topology):
             Best cost
         """
         try:
+            self.neighbor_idx = np.repeat(np.array([np.arange(swarm.n_particles)]), swarm.n_particles, axis=0)
             best_pos = swarm.pbest_pos[np.argmin(swarm.pbest_cost)]
             best_cost = np.min(swarm.pbest_cost)
         except AttributeError:

--- a/pyswarms/discrete/binary.py
+++ b/pyswarms/discrete/binary.py
@@ -19,10 +19,10 @@ proceeding equation:
 For the velocity update rule, a particle compares its current position
 with respect to its neighbours. The nearest neighbours are being
 determined by a kD-tree given a distance metric, similar to local-best
-PSO. However, this whole behavior can be modified into a global-best PSO
-by changing the nearest neighbours equal to the number of particles in
-the swarm. In this case, all particles see each other, and thus a global
-best particle can be established.
+PSO. The neighbours are computed for every iteration. However, this whole
+behavior can be modified into a global-best PSO by changing the nearest
+neighbours equal to the number of particles in the swarm. In this case,
+all particles see each other, and thus a global best particle can be established.
 
 In addition, one notable change for binary PSO is that the position
 update rule is now decided upon by the following case expression:
@@ -147,9 +147,9 @@ class BinaryPSO(DiscreteSwarmOptimizer):
         # Initialize the resettable attributes
         self.reset()
         # Initialize the topology
-        self.top = Ring()
+        self.top = Ring(static=False)
 
-    def optimize(self, objective_func, iters, print_step=1, verbose=1,**kwargs):
+    def optimize(self, objective_func, iters, print_step=1, verbose=1, **kwargs):
         """Optimizes the swarm for a number of iterations.
 
         Performs the optimization to evaluate the objective

--- a/pyswarms/single/general_optimizer.py
+++ b/pyswarms/single/general_optimizer.py
@@ -39,7 +39,7 @@ An example usage is as follows:
 
     # Set-up hyperparameters and topology
     options = {'c1': 0.5, 'c2': 0.3, 'w':0.9}
-    my_topology = Pyramid()
+    my_topology = Pyramid(static=False)
 
     # Call instance of GlobalBestPSO
     optimizer = ps.single.GeneralOptimizerPSO(n_particles=10, dimensions=2,
@@ -104,7 +104,7 @@ class GeneralOptimizerPSO(SwarmOptimizer):
                     number of neighbors to be considered. Must be a
                     positive integer less than :code:`n_particles`
                 if used with the :code:`Ring` topology the additional
-                parameter p must be included
+                parameters k and p must be included
                 * p: int {1,2}
                     the Minkowski p-norm to use. 1 is the
                     sum-of-absolute values (or L1 distance) while 2 is
@@ -115,12 +115,15 @@ class GeneralOptimizerPSO(SwarmOptimizer):
             are:
                 * Star
                     All particles are connected
-                * Ring
-                    Particles are connected with the k nearest neighbours
-                * Pyramid
+                * Ring (static and dynamic)
+                    Particles are connected to the k nearest neighbours
+                * Pyramid (static and dynamic)
                     Particles are connected in N-dimensional simplices
-                * Random
+                * Random (static and dynamic)
                     Particles are connected to k random particles
+                Static variants of the topologies remain with the same neighbours
+                over the course of the optimization. Dynamic variants calculate
+                new neighbours every time step.
         bounds : tuple of :code:`np.ndarray` (default is :code:`None`)
             a tuple of size 2 where the first entry is the minimum bound
             while the second entry is the maximum bound. Each array must
@@ -180,7 +183,7 @@ class GeneralOptimizerPSO(SwarmOptimizer):
                     "No. of neighbors must be an integer between"
                     "0 and no. of particles."
                 )
-            if not 0 <= self.k <= self.n_particles-1:
+            if not 0 <= self.k <= self.n_particles - 1:
                 raise ValueError(
                     "No. of neighbors must be between 0 and no. " "of particles."
                 )

--- a/pyswarms/single/local_best.py
+++ b/pyswarms/single/local_best.py
@@ -113,6 +113,7 @@ class LocalBestPSO(SwarmOptimizer):
         center=1.00,
         ftol=-np.inf,
         init_pos=None,
+        static=False
     ):
         """Initializes the swarm.
 
@@ -151,6 +152,9 @@ class LocalBestPSO(SwarmOptimizer):
                     the Minkowski p-norm to use. 1 is the
                     sum-of-absolute values (or L1 distance) while 2 is
                     the Euclidean (or L2) distance.
+        static: bool (Default is :code:`False`)
+            a boolean that decides whether the Ring topology
+            used is static or dynamic
         """
         # Initialize logger
         self.logger = logging.getLogger(__name__)
@@ -172,7 +176,7 @@ class LocalBestPSO(SwarmOptimizer):
         # Initialize the resettable attributes
         self.reset()
         # Initialize the topology
-        self.top = Ring(static=False)
+        self.top = Ring(static=static)
 
     def optimize(self, objective_func, iters, print_step=1, verbose=1, **kwargs):
         """Optimizes the swarm for a number of iterations.

--- a/pyswarms/single/local_best.py
+++ b/pyswarms/single/local_best.py
@@ -31,7 +31,7 @@ powerful explorative feature.
 In this implementation, a neighbor is selected via a k-D tree
 imported from :code:`scipy`. Distance are computed with either
 the L1 or L2 distance. The nearest-neighbours are then queried from
-this k-D tree.
+this k-D tree. They are computed for every iteration.
 
 An example usage is as follows:
 
@@ -172,7 +172,7 @@ class LocalBestPSO(SwarmOptimizer):
         # Initialize the resettable attributes
         self.reset()
         # Initialize the topology
-        self.top = Ring()
+        self.top = Ring(static=False)
 
     def optimize(self, objective_func, iters, print_step=1, verbose=1, **kwargs):
         """Optimizes the swarm for a number of iterations.

--- a/tests/backend/topology/conftest.py
+++ b/tests/backend/topology/conftest.py
@@ -11,7 +11,7 @@ import numpy as np
 from pyswarms.backend.swarms import Swarm
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def swarm():
     """A contrived instance of the Swarm class at a certain timestep"""
     attrs_at_t = {
@@ -27,7 +27,7 @@ def swarm():
     return Swarm(**attrs_at_t)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def k():
     """Default neighbor number"""
     _k = 1

--- a/tests/backend/topology/test_pyramid.py
+++ b/tests/backend/topology/test_pyramid.py
@@ -9,9 +9,10 @@ import numpy as np
 from pyswarms.backend.topology import Pyramid
 
 
-def test_compute_gbest_return_values(swarm):
+@pytest.mark.parametrize("static", [True, False])
+def test_compute_gbest_return_values(swarm, static):
     """Test if compute_gbest() gives the expected return values"""
-    topology = Pyramid()
+    topology = Pyramid(static=static)
     expected_cost = 1
     expected_pos = np.array([1, 2, 3])
     pos, cost = topology.compute_gbest(swarm)
@@ -19,23 +20,25 @@ def test_compute_gbest_return_values(swarm):
     assert (pos == expected_pos).all()
 
 
+@pytest.mark.parametrize("static", [True, False])
 @pytest.mark.parametrize("clamp", [None, (0, 1), (-1, 1)])
-def test_compute_velocity_return_values(swarm, clamp):
+def test_compute_velocity_return_values(swarm, clamp, static):
     """Test if compute_velocity() gives the expected shape and range"""
-    topology = Pyramid()
+    topology = Pyramid(static=static)
     v = topology.compute_velocity(swarm, clamp)
     assert v.shape == swarm.position.shape
     if clamp is not None:
         assert (clamp[0] <= v).all() and (clamp[1] >= v).all()
 
 
+@pytest.mark.parametrize("static", [True, False])
 @pytest.mark.parametrize(
     "bounds",
     [None, ([-5, -5, -5], [5, 5, 5]), ([-10, -10, -10], [10, 10, 10])],
 )
-def test_compute_position_return_values(swarm, bounds):
+def test_compute_position_return_values(swarm, bounds, static):
     """Test if compute_position() gives the expected shape and range"""
-    topology = Pyramid()
+    topology = Pyramid(static=static)
     p = topology.compute_position(swarm, bounds)
     assert p.shape == swarm.velocity.shape
     if bounds is not None:

--- a/tests/backend/topology/test_random.py
+++ b/tests/backend/topology/test_random.py
@@ -9,10 +9,11 @@ import numpy as np
 from pyswarms.backend.topology import Random
 
 
+@pytest.mark.parametrize("static", [True, False])
 @pytest.mark.parametrize("k", [1, 2])
-def test_update_gbest_neighborhood(swarm, k):
+def test_update_gbest_neighborhood(swarm, k, static):
     """Test if update_gbest_neighborhood gives the expected return values"""
-    topology = Random()
+    topology = Random(static=static)
     pos, cost = topology.compute_gbest(swarm, k=k)
     expected_pos = np.array([1, 2, 3])
     expected_cost = 1
@@ -20,42 +21,46 @@ def test_update_gbest_neighborhood(swarm, k):
     assert cost == expected_cost
 
 
+@pytest.mark.parametrize("static", [True, False])
 @pytest.mark.parametrize("clamp", [None, (0, 1), (-1, 1)])
-def test_compute_velocity_return_values(swarm, clamp):
+def test_compute_velocity_return_values(swarm, clamp, static):
     """Test if compute_velocity() gives the expected shape and range"""
-    topology = Random()
+    topology = Random(static=static)
     v = topology.compute_velocity(swarm, clamp)
     assert v.shape == swarm.position.shape
     if clamp is not None:
         assert (clamp[0] <= v).all() and (clamp[1] >= v).all()
 
 
+@pytest.mark.parametrize("static", [True, False])
 @pytest.mark.parametrize(
     "bounds",
     [None, ([-5, -5, -5], [5, 5, 5]), ([-10, -10, -10], [10, 10, 10])],
 )
-def test_compute_position_return_values(swarm, bounds):
+def test_compute_position_return_values(swarm, bounds, static):
     """Test if compute_position() gives the expected shape and range"""
-    topology = Random()
+    topology = Random(static=static)
     p = topology.compute_position(swarm, bounds)
     assert p.shape == swarm.velocity.shape
     if bounds is not None:
         assert (bounds[0] <= p).all() and (bounds[1] >= p).all()
 
 
+@pytest.mark.parametrize("static", [True, False])
 @pytest.mark.parametrize("k", [1, 2])
-def test_compute_neighbors_return_values(swarm, k):
+def test_compute_neighbors_return_values(swarm, k, static):
     """Test if __compute_neighbors() gives the expected shape and symmetry"""
-    topology = Random()
+    topology = Random(static=static)
     adj_matrix = topology._Random__compute_neighbors(swarm, k)
     assert adj_matrix.shape == (swarm.n_particles, swarm.n_particles)
     assert np.allclose(adj_matrix, adj_matrix.T, atol=1e-8)  # Symmetry test
 
 
-def test_compute_neighbors_adjacency_matrix(swarm, k):
+@pytest.mark.parametrize("static", [True, False])
+def test_compute_neighbors_adjacency_matrix(swarm, k, static):
     """Test if __compute_neighbors() gives the expected matrix"""
     np.random.seed(1)
-    topology = Random()
+    topology = Random(static=static)
     adj_matrix = topology._Random__compute_neighbors(swarm, k)
     comparison_matrix = np.array([[1, 1, 0], [1, 1, 1], [0, 1, 1]])
     assert np.allclose(adj_matrix, comparison_matrix, atol=1e-8)

--- a/tests/backend/topology/test_ring.py
+++ b/tests/backend/topology/test_ring.py
@@ -9,11 +9,12 @@ import numpy as np
 from pyswarms.backend.topology import Ring
 
 
+@pytest.mark.parametrize("static", [True, False])
 @pytest.mark.parametrize("k", [1, 2, 3])
 @pytest.mark.parametrize("p", [1, 2])
-def test_update_gbest_neighborhood(swarm, p, k):
+def test_update_gbest_neighborhood(swarm, p, k, static):
     """Test if update_gbest_neighborhood gives the expected return values"""
-    topology = Ring()
+    topology = Ring(static=static)
     pos, cost = topology.compute_gbest(swarm, p=p, k=k)
     expected_pos = np.array([1, 2, 3])
     expected_cost = 1
@@ -21,23 +22,25 @@ def test_update_gbest_neighborhood(swarm, p, k):
     assert cost == expected_cost
 
 
+@pytest.mark.parametrize("static", [True, False])
 @pytest.mark.parametrize("clamp", [None, (0, 1), (-1, 1)])
-def test_compute_velocity_return_values(swarm, clamp):
+def test_compute_velocity_return_values(swarm, clamp, static):
     """Test if compute_velocity() gives the expected shape and range"""
-    topology = Ring()
+    topology = Ring(static=static)
     v = topology.compute_velocity(swarm, clamp)
     assert v.shape == swarm.position.shape
     if clamp is not None:
         assert (clamp[0] <= v).all() and (clamp[1] >= v).all()
 
 
+@pytest.mark.parametrize("static", [True, False])
 @pytest.mark.parametrize(
     "bounds",
     [None, ([-5, -5, -5], [5, 5, 5]), ([-10, -10, -10], [10, 10, 10])],
 )
-def test_compute_position_return_values(swarm, bounds):
+def test_compute_position_return_values(swarm, bounds, static):
     """Test if compute_position() gives the expected shape and range"""
-    topology = Ring()
+    topology = Ring(static=static)
     p = topology.compute_position(swarm, bounds)
     assert p.shape == swarm.velocity.shape
     if bounds is not None:

--- a/tests/optimizers/conftest.py
+++ b/tests/optimizers/conftest.py
@@ -14,32 +14,20 @@ from pyswarms.utils.functions.single_obj import sphere_func
 from pyswarms.backend.topology import Star, Ring, Pyramid, Random
 
 
-@pytest.fixture(scope="module",
-                params=[
-                    Star(),
-                    Ring(),
-                    Pyramid(),
-                    Random()
-                ])
-def general_opt_history(top):
+@pytest.fixture(scope="module")
+def general_opt_history(topology):
     """Returns a GeneralOptimizerPSO instance run for 1000 iterations for checking
     history"""
-    pso = GeneralOptimizerPSO(10, 2, {"c1": 0.5, "c2": 0.7, "w": 0.5}, topology=top)
+    pso = GeneralOptimizerPSO(10, 2, {"c1": 0.5, "c2": 0.7, "w": 0.5}, topology=topology)
     pso.optimize(sphere_func, 1000, verbose=0)
     return pso
 
 
-@pytest.fixture(scope="module",
-                params=[
-                    Star(),
-                    Ring(),
-                    Pyramid(),
-                    Random()
-                ])
-def general_opt_reset(top):
+@pytest.fixture(scope="module")
+def general_opt_reset(topology):
     """Returns a GeneralOptimizerPSO instance that has been run and reset to check
     default value"""
-    pso = GeneralOptimizerPSO(10, 2, {"c1": 0.5, "c2": 0.7, "w": 0.5}, topology=top)
+    pso = GeneralOptimizerPSO(10, 2, {"c1": 0.5, "c2": 0.7, "w": 0.5}, topology=topology)
     pso.optimize(sphere_func, 10, verbose=0)
     pso.reset()
     return pso
@@ -109,8 +97,20 @@ def options():
     return options_
 
 
-@pytest.fixture
-def topology():
-    """Default topology for most PSO use-cases"""
-    topology_ = Pyramid()
+@pytest.fixture(params=[
+                Star(),
+                Ring(static=False), Ring(static=True),
+                Pyramid(static=False), Pyramid(static=True),
+                Random(static=False), Random(static=True)
+                ])
+def topology(request):
+    """Parametrized topology parameter"""
+    topology_ = request.param
     return topology_
+
+
+@pytest.fixture(scope="module", params=[True, False])
+def static(request):
+    """Parametrized static parameter"""
+    static_ = request.param
+    return static_

--- a/tests/optimizers/test_general_optimizer.py
+++ b/tests/optimizers/test_general_optimizer.py
@@ -31,10 +31,10 @@ def test_keyword_exception(options, topology):
         {"c1": 0.5, "c2": 0.7, "w": 0.5, "k": 2},
     ],
 )
-def test_keyword_exception_ring(options):
+def test_keyword_exception_ring(options, static):
     """Tests if exceptions are thrown when keywords are missing and a Ring topology is chosen"""
     with pytest.raises(KeyError):
-        GeneralOptimizerPSO(5, 2, options, Ring())
+        GeneralOptimizerPSO(5, 2, options, Ring(static=static))
 
 
 @pytest.mark.parametrize(
@@ -46,10 +46,10 @@ def test_keyword_exception_ring(options):
         {"c1": 0.5, "c2": 0.7, "w": 0.5},
     ],
 )
-def test_keyword_exception_random(options):
+def test_keyword_exception_random(options, static):
     """Tests if exceptions are thrown when keywords are missing and a Random topology is chosen"""
     with pytest.raises(KeyError):
-        GeneralOptimizerPSO(5, 2, options, Random())
+        GeneralOptimizerPSO(5, 2, options, Random(static=static))
 
 
 @pytest.mark.parametrize(
@@ -60,11 +60,11 @@ def test_keyword_exception_random(options):
         {"c1": 0.5, "c2": 0.7, "w": 0.5, "k": 2, "p": 5},
     ],
 )
-def test_invalid_k_or_p_values(options):
+def test_invalid_k_or_p_values(options, static):
     """Tests if exception is thrown when passing
     an invalid value for k or p when using a Ring topology"""
     with pytest.raises(ValueError):
-        GeneralOptimizerPSO(5, 2, options, Ring())
+        GeneralOptimizerPSO(5, 2, options, Ring(static=static))
 
 
 @pytest.mark.parametrize(
@@ -75,11 +75,11 @@ def test_invalid_k_or_p_values(options):
         {"c1": 0.5, "c2": 0.7, "w": 0.5, "k": 0.5}
     ],
 )
-def test_invalid_k_value(options):
+def test_invalid_k_value(options, static):
     """Tests if exception is thrown when passing
     an invalid value for k when using a Random topology"""
     with pytest.raises(ValueError):
-        GeneralOptimizerPSO(5, 2, options, Random())
+        GeneralOptimizerPSO(5, 2, options, Random(static=static))
 
 
 @pytest.mark.parametrize(
@@ -92,10 +92,6 @@ def test_topology_type_exception(options, topology):
         GeneralOptimizerPSO(5, 2, options, topology)
 
 
-@pytest.mark.parametrize(
-    "topology",
-    [Star(), Ring(), Pyramid(), Random()]
-)
 @pytest.mark.parametrize(
     "bounds",
     [
@@ -111,10 +107,6 @@ def test_bounds_size_exception(bounds, options, topology):
 
 
 @pytest.mark.parametrize(
-    "topology",
-    [Star(), Ring(), Pyramid(), Random()]
-)
-@pytest.mark.parametrize(
     "bounds",
     [
         (np.array([5, 5]), np.array([-5, -5])),
@@ -128,10 +120,6 @@ def test_bounds_maxmin_exception(bounds, options, topology):
 
 
 @pytest.mark.parametrize(
-    "topology",
-    [Star(), Ring(), Pyramid(), Random()]
-)
-@pytest.mark.parametrize(
     "bounds",
     [
         [np.array([-5, -5]), np.array([5, 5])],
@@ -144,10 +132,6 @@ def test_bound_type_exception(bounds, options, topology):
         GeneralOptimizerPSO(5, 2, options=options, topology=topology, bounds=bounds)
 
 
-@pytest.mark.parametrize(
-    "topology",
-    [Star(), Ring(), Pyramid(), Random()]
-)
 @pytest.mark.parametrize("velocity_clamp", [(1, 1, 1), (2, 3, 1)])
 def test_vclamp_shape_exception(velocity_clamp, options, topology):
     """Tests if exception is raised when velocity_clamp's size is not equal
@@ -156,10 +140,6 @@ def test_vclamp_shape_exception(velocity_clamp, options, topology):
         GeneralOptimizerPSO(5, 2, velocity_clamp=velocity_clamp, options=options, topology=topology)
 
 
-@pytest.mark.parametrize(
-    "topology",
-    [Star(), Ring(), Pyramid(), Random()]
-)
 @pytest.mark.parametrize("velocity_clamp", [(3, 2), (10, 8)])
 def test_vclamp_maxmin_exception(velocity_clamp, options, topology):
     """Tests if the max velocity_clamp is less than min velocity_clamp and
@@ -168,10 +148,6 @@ def test_vclamp_maxmin_exception(velocity_clamp, options, topology):
         GeneralOptimizerPSO(5, 2, velocity_clamp=velocity_clamp, options=options, topology=topology)
 
 
-@pytest.mark.parametrize(
-    "topology",
-    [Star(), Ring(), Pyramid(), Random()]
-)
 @pytest.mark.parametrize("err, center", [(IndexError, [1.5, 3.2, 2.5])])
 def test_center_exception(err, center, options, topology):
     """Tests if exception is thrown when center is not a list or of different shape"""
@@ -201,10 +177,7 @@ def test_training_history_shape(gbest_history, history, expected_shape):
     pso = vars(gbest_history)
     assert np.array(pso[history]).shape == expected_shape
 
-@pytest.mark.parametrize(
-    "topology",
-    [Star(), Ring(), Pyramid(), Random()]
-)
+
 def test_ftol_effect(options, topology):
     """Test if setting the ftol breaks the optimization process accodingly"""
     pso = GeneralOptimizerPSO(10, 2, options=options, topology=topology, ftol=1e-1)


### PR DESCRIPTION
## Description
I added a new functionality to the topologies with which one can decide if the topology is static (i.e. the neighbours don't change over the course of the optimization) or dynamic (i.e. the neighbours change over the course of the optimization). This new functionality includes the addition of two new attributes to the topology classes that can be static or dynamic:

* `static`: a boolean that decides whether the topology is static or not
* `neighbor_idx`: a matrix with the neighbor indices for every particle.

To initialize a topology it is now necessary to set the `static` attribute like so:

```python
Pyramid(static=True)
```

The other functionalities remain unchanged.

I also changed the tests to have new parametrizations so it works without a lot of `pytest` marks. The documentation has been updated according to the changes.
The local and global optimizers have now dynamic topologies (same as before but now explicitly stated in the documentation and the code).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#129 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This new feature makes it possible to choose whether the neighbours are computed every iteration or just in the first one. This reduces the computation steps for every iteration if one does not consider a dynamic topology as important.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The tests were extended with the new constructor parameter so all the test now check the dynamic and the static variant.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would mildly cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests pass.

