### PR TITLE
Fix plotter module (#167)

### DIFF
--- a/pyswarms/utils/plotters/formatters.py
+++ b/pyswarms/utils/plotters/formatters.py
@@ -10,6 +10,7 @@ This module implements helpful classes to format your plots or create meshes.
 import numpy as np
 from attr import attrs, attrib
 from attr.validators import instance_of
+from matplotlib import cm
 
 
 @attrs
@@ -57,10 +58,15 @@ class Designer(object):
     )
     legend = attrib(validator=instance_of(str), default="Cost")
     label = attrib(
-        validator=instance_of((str, list, tuple)), default=["x-axis", "y-axis"]
+        validator=instance_of((str, list, tuple)),
+        default=["x-axis", "y-axis", "z-axis"],
     )
     limits = attrib(
         validator=instance_of((list, tuple)), default=[(-1, 1), (-1, 1)]
+    )
+    colormap = attrib(
+        validator=instance_of((type(cm.viridis), type(cm.binary))),
+        default=cm.viridis,
     )
 
 

--- a/pyswarms/utils/plotters/formatters.py
+++ b/pyswarms/utils/plotters/formatters.py
@@ -10,7 +10,7 @@ This module implements helpful classes to format your plots or create meshes.
 import numpy as np
 from attr import attrs, attrib
 from attr.validators import instance_of
-from matplotlib import cm
+from matplotlib import cm, colors
 
 
 @attrs
@@ -65,7 +65,7 @@ class Designer(object):
         validator=instance_of((list, tuple)), default=[(-1, 1), (-1, 1), (-1, 1)]
     )
     colormap = attrib(
-        validator=instance_of((type(cm.viridis), type(cm.binary))),
+        validator=instance_of(colors.Colormap),
         default=cm.viridis,
     )
 

--- a/pyswarms/utils/plotters/formatters.py
+++ b/pyswarms/utils/plotters/formatters.py
@@ -62,7 +62,7 @@ class Designer(object):
         default=["x-axis", "y-axis", "z-axis"],
     )
     limits = attrib(
-        validator=instance_of((list, tuple)), default=[(-1, 1), (-1, 1)]
+        validator=instance_of((list, tuple)), default=[(-1, 1), (-1, 1), (-1, 1)]
     )
     colormap = attrib(
         validator=instance_of((type(cm.viridis), type(cm.binary))),

--- a/pyswarms/utils/plotters/plotters.py
+++ b/pyswarms/utils/plotters/plotters.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-r"""
+"""
 Plotting tool for Optimizer Analysis
 
 This module is built on top of :code:`matplotlib` to render quick and easy
@@ -322,12 +322,14 @@ def plot_surface(
             designer = Designer(
                 limits=[(-1, 1), (-1, 1), (-1, 1)],
                 label=["x-axis", "y-axis", "z-axis"],
+                colormap=cm.viridis,
             )
 
         # If no Animator class supplied, use defaults
         if animator is None:
             animator = Animator()
 
+        # Get number of iterations
         # If ax is default, then create new plot. Set-up the figure, the
         # axis, and the plot element that we want to animate
         if canvas is None:
@@ -338,7 +340,6 @@ def plot_surface(
         # Initialize 3D-axis
         ax = Axes3D(fig)
 
-        # Get number of iterations
         n_iters = len(pos_history)
 
         # Customize plot
@@ -353,7 +354,9 @@ def plot_surface(
         # Make a contour map if possible
         if mesher is not None:
             xx, yy, zz, = _mesh(mesher)
-            ax.plot_surface(xx, yy, zz, cmap=cm.viridis, alpha=mesher.alpha)
+            ax.plot_surface(
+                xx, yy, zz, cmap=designer.colormap, alpha=mesher.alpha
+            )
 
         # Mark global best if possible
         if mark is not None:


### PR DESCRIPTION
## Description

Bug fix: Added 'z-axis' to formatters/Designer attribute 'labels' to prevent index out of range error when plotting in 3D. Also added a third dimension to 'limits' for the same reason. 

New feature:  I added a colormaps property to the Designer class in formatters.py to allow the user to choose whichever one they want. It uses the same style as other properties of the class, and the module imports matplotlib.cm to validate both types of colormaps in matplotlib. I edited plotters/plot_countour to initialize a Designer object with a default colormap if none is provided. I've tested with every category of colormap as well as custom colormaps and verified that it is working as intended.

Default parameter change: Mesher.delta from 0.001 to 0.1. This makes it safe to run many of the functions on an average computer. With 0.001, the mesher object grows very quickly. 

## Related Issue

Fix plotter module (#167)

## Motivation and Context

Adding a colormap attribute to Designer made easier to verify the functions. I implemented because it enabled me to use discreet colormaps. 

## How Has This Been Tested?

Then I used flask8 and black. I restricted flask8 and black testing to the files that I edited in each commit. I also ran py.test. 

I tested Designer on all types of matplotlib colormaps. I didn't add a test to do this automatically, but it will return a TypeError if it's not a valid colormap. Does it need a test? 

## Screenshots (if appropriate):
![sphere_example](https://user-images.githubusercontent.com/26357788/42856159-c22bc152-89f8-11e8-8888-15d95cce0c58.jpg)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

