### PR TITLE
Fix pyyaml version vulnerability

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,7 +8,7 @@ tox==3.0.0
 coverage==4.5.1
 Sphinx==1.7.5
 cryptography==2.2.2
-PyYAML==3.13
+PyYAML>=3.13
 future==0.16.0
 scipy>=0.17.0
 numpy>=1.13.0


### PR DESCRIPTION
By unpinning the pyyaml version, we can install higher (perhaps > 4.00)
versions.

Signed-off-by: Lester James V. Miranda <ljvmiranda@gmail.com>