### PR TITLE
Ignore PyYAML dependency

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,7 +8,7 @@ tox==3.0.0
 coverage==4.5.1
 Sphinx==1.7.5
 cryptography==2.2.2
-PyYAML==3.12
+PyYAML==3.12 # pyup: ignore
 future==0.16.0
 scipy>=0.17.0
 numpy>=1.13.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.rst', encoding="utf8") as history_file:
     history = history_file.read()
 
 requirements = [
-    'PyYAML==3.12',
+    'PyYAML==3.13',
     'future==0.16.0',
     'scipy>=0.17.0',
     'numpy>=1.13.0',
@@ -28,7 +28,7 @@ setup_requirements = [
 ]
 
 test_requirements = [
-    'PyYAML==3.12',
+    'PyYAML==3.13',
     'future==0.16.0',
     'scipy>=0.17.0',
     'numpy>=1.13.0',


### PR DESCRIPTION
I guess it's better to have pyup ignore the PyYAML dependency. We're only using yaml to configure our logging files so it's not really that relevant as compared to numpy or matplotlib