### PR TITLE
Fix pyyaml dependency

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,7 +8,7 @@ tox==3.0.0
 coverage==4.5.1
 Sphinx==1.7.5
 cryptography==2.2.2
-PyYAML==3.13
+PyYAML==3.13 # pyup: ignore
 future==0.16.0
 scipy>=0.17.0
 numpy>=1.13.0


### PR DESCRIPTION
It turns out that pyup and pyyaml has anomalous versions and
has become buggy. We fix this dependency by having pyup ignore
such changes. PyYAML is only used for our logging configs, so
this will not be harmful.

Signed-off-by: Lester James V. Miranda <ljvmiranda@gmail.com>