### PR TITLE
Clean up changes for v0.3.0

### DIFF
--- a/pyswarms/backend/topology/pyramid.py
+++ b/pyswarms/backend/topology/pyramid.py
@@ -36,12 +36,15 @@ class Pyramid(Topology):
     def compute_gbest(self, swarm):
         """Update the global best using a pyramid neighborhood approach
 
-        This topology uses the Delaunay method from :code:`scipy`. This method is used to triangulate
-        N-dimensional space into simplices. The vertices of the simplicies consist of swarm particles. [SIS2008]
+        This topology uses the :code:`Delaunay` class from :code:`scipy`. To prevent precision errors in the Delaunay
+        class, custom :code:`qhull_options` were added. Namely, :code:`QJ0.001 Qbb Qc Qx`. The meaning of those options
+        is explained in [qhull]. This method is used to triangulate N-dimensional space into simplices. The vertices of
+        the simplicies consist of swarm particles. This method is adapted from the work of Lane et al.[SIS2008]
 
         [SIS2008] J. Lane, A. Engelbrecht and J. Gain, "Particle swarm optimization with spatially
         meaningful neighbours," 2008 IEEE Swarm Intelligence Symposium, St. Louis, MO, 2008,
         pp. 1-8. doi: 10.1109/SIS.2008.4668281
+        [qhull] http://www.qhull.org/html/qh-optq.htm
 
         Parameters
         ----------
@@ -56,15 +59,15 @@ class Pyramid(Topology):
             Best cost
         """
         try:
-            # If there are less than 5 particles they are all connected
-            if swarm.n_particles < 5:
+            # If there are less than (swarm.dimensions + 1) particles they are all connected
+            if swarm.n_particles < swarm.dimensions + 1:
                 self.neighbor_idx = np.tile(np.arange(swarm.n_particles), (swarm.n_particles, 1))
                 best_pos = swarm.pbest_pos[np.argmin(swarm.pbest_cost)]
                 best_cost = np.min(swarm.pbest_cost)
             else:
                 # Check if the topology is static or dynamic and assign neighbors
                 if (self.static and self.neighbor_idx is None) or not self.static:
-                    pyramid = Delaunay(swarm.position)
+                    pyramid = Delaunay(swarm.position, qhull_options="QJ0.001 Qbb Qc Qx")
                     indices, index_pointer = pyramid.vertex_neighbor_vertices
                     # Insert all the neighbors for each particle in the idx array
                     self.neighbor_idx = np.array(

--- a/pyswarms/backend/topology/star.py
+++ b/pyswarms/backend/topology/star.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 class Star(Topology):
     def __init__(self):
-        super(Star, self).__init__(static=False)
+        super(Star, self).__init__(static=True)
 
     def compute_gbest(self, swarm):
         """Update the global best using a star topology
@@ -61,7 +61,8 @@ class Star(Topology):
             Best cost
         """
         try:
-            self.neighbor_idx = np.tile(np.arange(swarm.n_particles), (swarm.n_particles, 1))
+            if self.neighbor_idx is None:
+                self.neighbor_idx = np.tile(np.arange(swarm.n_particles), (swarm.n_particles, 1))
             best_pos = swarm.pbest_pos[np.argmin(swarm.pbest_cost)]
             best_cost = np.min(swarm.pbest_cost)
         except AttributeError:

--- a/pyswarms/backend/topology/von_neumann.py
+++ b/pyswarms/backend/topology/von_neumann.py
@@ -19,7 +19,7 @@ class VonNeumann(Ring):
     def __init__(self):
         super(VonNeumann, self).__init__(static=True)
 
-    def compute_gbest(self, swarm, p=1, r=1):
+    def compute_gbest(self, swarm, p, r):
         """Updates the global best using a neighborhood approach
 
         The Von Neumann topology inherits from the Ring topology and uses

--- a/pyswarms/backend/topology/von_neumann.py
+++ b/pyswarms/backend/topology/von_neumann.py
@@ -71,7 +71,8 @@ class VonNeumann(Ring):
         if d == 0 or r == 0:
             return 1
         else:
-            del_number = VonNeumann.delannoy(d - 1, r)\
-                         + VonNeumann.delannoy(d - 1, r - 1)\
-                         + VonNeumann.delannoy(d, r - 1)
+            del_number = (VonNeumann.delannoy(d - 1, r)
+                          + VonNeumann.delannoy(d - 1, r - 1)
+                          + VonNeumann.delannoy(d, r - 1)
+                          )
             return del_number

--- a/pyswarms/discrete/binary.py
+++ b/pyswarms/discrete/binary.py
@@ -149,7 +149,7 @@ class BinaryPSO(DiscreteSwarmOptimizer):
         # Initialize the topology
         self.top = Ring(static=False)
 
-    def optimize(self, objective_func, iters, print_step=1, verbose=1,**kwargs):
+    def optimize(self, objective_func, iters, print_step=1, verbose=1, **kwargs):
         """Optimize the swarm for a number of iterations
 
         Performs the optimization to evaluate the objective
@@ -257,4 +257,3 @@ class BinaryPSO(DiscreteSwarmOptimizer):
             Output sigmoid computation
         """
         return 1 / (1 + np.exp(-x))
-

--- a/tests/backend/topology/test_pyramid.py
+++ b/tests/backend/topology/test_pyramid.py
@@ -49,5 +49,5 @@ def test_compute_position_return_values(swarm, bounds, static):
 def test_neighbor_idx(swarm, static):
     """Test if the neighbor_idx attribute is assigned"""
     topology = Pyramid(static=static)
-    p = topology.compute_gbest(swarm)
+    topology.compute_gbest(swarm)
     assert topology.neighbor_idx is not None

--- a/tests/backend/topology/test_random.py
+++ b/tests/backend/topology/test_random.py
@@ -81,5 +81,5 @@ def test_compute_neighbors_adjacency_matrix(swarm, k, static):
 def test_neighbor_idx(swarm, k, static):
     """Test if the neighbor_idx attribute is assigned"""
     topology = Random(static=static)
-    p = topology.compute_gbest(swarm, k)
+    topology.compute_gbest(swarm, k)
     assert topology.neighbor_idx is not None

--- a/tests/backend/topology/test_ring.py
+++ b/tests/backend/topology/test_ring.py
@@ -53,5 +53,5 @@ def test_compute_position_return_values(swarm, bounds, static):
 def test_neighbor_idx(swarm, static, p, k):
     """Test if the neighbor_idx attribute is assigned"""
     topology = Ring(static=static)
-    p = topology.compute_gbest(swarm, p=p, k=k)
+    topology.compute_gbest(swarm, p=p, k=k)
     assert topology.neighbor_idx is not None

--- a/tests/backend/topology/test_star.py
+++ b/tests/backend/topology/test_star.py
@@ -45,5 +45,5 @@ def test_compute_position_return_values(swarm, bounds):
 def test_neighbor_idx(swarm):
     """Test if the neighbor_idx attribute is assigned"""
     topology = Star()
-    p = topology.compute_gbest(swarm)
+    topology.compute_gbest(swarm)
     assert topology.neighbor_idx is not None

--- a/tests/backend/topology/test_von_neumann.py
+++ b/tests/backend/topology/test_von_neumann.py
@@ -49,7 +49,7 @@ def test_compute_position_return_values(swarm, bounds):
 def test_neighbor_idx(swarm, p, r):
     """Test if the neighbor_idx attribute is assigned"""
     topology = VonNeumann()
-    p = topology.compute_gbest(swarm, p=p, r=r)
+    topology.compute_gbest(swarm, p=p, r=r)
     assert topology.neighbor_idx is not None
 
 

--- a/tests/optimizers/conftest.py
+++ b/tests/optimizers/conftest.py
@@ -11,7 +11,7 @@ import numpy as np
 from pyswarms.single import GlobalBestPSO, LocalBestPSO, GeneralOptimizerPSO
 from pyswarms.discrete import BinaryPSO
 from pyswarms.utils.functions.single_obj import sphere_func
-from pyswarms.backend.topology import Star, Ring, Pyramid, Random
+from pyswarms.backend.topology import Star, Ring, Pyramid, Random, VonNeumann
 
 
 @pytest.fixture(scope="module")
@@ -93,7 +93,7 @@ def binary_reset():
 @pytest.fixture
 def options():
     """Default options dictionary for most PSO use-cases"""
-    options_ = {"c1": 0.5, "c2": 0.7, "w": 0.5, "k": 2, "p": 2}
+    options_ = {"c1": 0.5, "c2": 0.7, "w": 0.5, "k": 2, "p": 2, "r": 1}
     return options_
 
 
@@ -101,16 +101,10 @@ def options():
                 Star(),
                 Ring(static=False), Ring(static=True),
                 Pyramid(static=False), Pyramid(static=True),
-                Random(static=False), Random(static=True)
+                Random(static=False), Random(static=True),
+                VonNeumann()
                 ])
 def topology(request):
     """Parametrized topology parameter"""
     topology_ = request.param
     return topology_
-
-
-@pytest.fixture(scope="module", params=[True, False])
-def static(request):
-    """Parametrized static parameter"""
-    static_ = request.param
-    return static_

--- a/tests/optimizers/test_general_optimizer.py
+++ b/tests/optimizers/test_general_optimizer.py
@@ -7,7 +7,7 @@ import numpy as np
 
 # Import from package
 from pyswarms.single import GeneralOptimizerPSO
-from pyswarms.backend.topology import Star, Ring, Pyramid, Random
+from pyswarms.backend.topology import Star, Ring, Pyramid, Random, VonNeumann
 from pyswarms.utils.functions.single_obj import sphere_func
 
 
@@ -21,6 +21,7 @@ def test_keyword_exception(options, topology):
         GeneralOptimizerPSO(5, 2, options, topology)
 
 
+@pytest.mark.parametrize("static", [True, False])
 @pytest.mark.parametrize(
     "options",
     [
@@ -37,6 +38,24 @@ def test_keyword_exception_ring(options, static):
         GeneralOptimizerPSO(5, 2, options, Ring(static=static))
 
 
+@pytest.mark.parametrize("static", [True, False])
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"c2": 0.7, "w": 0.5, "r": 2, "p": 2},
+        {"c1": 0.5, "w": 0.5, "r": 2, "p": 2},
+        {"c1": 0.5, "c2": 0.7, "r": 2, "p": 2},
+        {"c1": 0.5, "c2": 0.7, "w": 0.5, "p": 2},
+        {"c1": 0.5, "c2": 0.7, "w": 0.5, "r": 2},
+    ],
+)
+def test_keyword_exception_vonneumann(options, static):
+    """Tests if exceptions are thrown when keywords are missing and a VonNeumann topology is chosen"""
+    with pytest.raises(KeyError):
+        GeneralOptimizerPSO(5, 2, options, VonNeumann())
+
+
+@pytest.mark.parametrize("static", [True, False])
 @pytest.mark.parametrize(
     "options",
     [
@@ -52,21 +71,7 @@ def test_keyword_exception_random(options, static):
         GeneralOptimizerPSO(5, 2, options, Random(static=static))
 
 
-@pytest.mark.parametrize(
-    "options",
-    [
-        {"c2": 0.7, "w": 0.5, "k": 2},
-        {"c1": 0.5, "w": 0.5, "k": 2},
-        {"c1": 0.5, "c2": 0.7, "k": 2},
-        {"c1": 0.5, "c2": 0.7, "w": 0.5},
-    ],
-)
-def test_keyword_exception_random(options):
-    """Tests if exceptions are thrown when keywords are missing and a Random topology is chosen"""
-    with pytest.raises(KeyError):
-        GeneralOptimizerPSO(5, 2, options, Random())
-
-
+@pytest.mark.parametrize("static", [True, False])
 @pytest.mark.parametrize(
     "options",
     [
@@ -85,6 +90,22 @@ def test_invalid_k_or_p_values(options, static):
 @pytest.mark.parametrize(
     "options",
     [
+        {"c1": 0.5, "c2": 0.7, "w": 0.5, "r": -1, "p": 2},
+        {"c1": 0.5, "c2": 0.7, "w": 0.5, "r": 6, "p": 2},
+        {"c1": 0.5, "c2": 0.7, "w": 0.5, "r": 2, "p": 5},
+    ],
+)
+def test_invalid_r_or_p_values(options):
+    """Tests if exception is thrown when passing
+    an invalid value for r or p when using a Von Neumann topology"""
+    with pytest.raises(ValueError):
+        GeneralOptimizerPSO(5, 2, options, VonNeumann())
+
+
+@pytest.mark.parametrize("static", [True, False])
+@pytest.mark.parametrize(
+    "options",
+    [
         {"c1": 0.5, "c2": 0.7, "w": 0.5, "k": -1},
         {"c1": 0.5, "c2": 0.7, "w": 0.5, "k": 6},
         {"c1": 0.5, "c2": 0.7, "w": 0.5, "k": 0.5}
@@ -98,21 +119,6 @@ def test_invalid_k_value(options, static):
 
 
 @pytest.mark.parametrize(
-    "options",
-    [
-        {"c1": 0.5, "c2": 0.7, "w": 0.5, "k": -1},
-        {"c1": 0.5, "c2": 0.7, "w": 0.5, "k": 6},
-        {"c1": 0.5, "c2": 0.7, "w": 0.5, "k": 0.5}
-    ],
-)
-def test_invalid_k_value(options):
-    """Tests if exception is thrown when passing
-    an invalid value for k when using a Random topology"""
-    with pytest.raises(ValueError):
-        GeneralOptimizerPSO(5, 2, options, Random())
-
-
-@pytest.mark.parametrize(
     "topology",
     [object(), int(), dict()]
 )
@@ -122,10 +128,6 @@ def test_topology_type_exception(options, topology):
         GeneralOptimizerPSO(5, 2, options, topology)
 
 
-@pytest.mark.parametrize(
-    "topology",
-    [Star(), Ring(), Pyramid(), Random()]
-)
 @pytest.mark.parametrize(
     "bounds",
     [
@@ -141,10 +143,6 @@ def test_bounds_size_exception(bounds, options, topology):
 
 
 @pytest.mark.parametrize(
-    "topology",
-    [Star(), Ring(), Pyramid(), Random()]
-)
-@pytest.mark.parametrize(
     "bounds",
     [
         (np.array([5, 5]), np.array([-5, -5])),
@@ -158,10 +156,6 @@ def test_bounds_maxmin_exception(bounds, options, topology):
 
 
 @pytest.mark.parametrize(
-    "topology",
-    [Star(), Ring(), Pyramid(), Random()]
-)
-@pytest.mark.parametrize(
     "bounds",
     [
         [np.array([-5, -5]), np.array([5, 5])],
@@ -174,10 +168,6 @@ def test_bound_type_exception(bounds, options, topology):
         GeneralOptimizerPSO(5, 2, options=options, topology=topology, bounds=bounds)
 
 
-@pytest.mark.parametrize(
-    "topology",
-    [Star(), Ring(), Pyramid(), Random()]
-)
 @pytest.mark.parametrize("velocity_clamp", [(1, 1, 1), (2, 3, 1)])
 def test_vclamp_shape_exception(velocity_clamp, options, topology):
     """Tests if exception is raised when velocity_clamp's size is not equal
@@ -186,10 +176,6 @@ def test_vclamp_shape_exception(velocity_clamp, options, topology):
         GeneralOptimizerPSO(5, 2, velocity_clamp=velocity_clamp, options=options, topology=topology)
 
 
-@pytest.mark.parametrize(
-    "topology",
-    [Star(), Ring(), Pyramid(), Random()]
-)
 @pytest.mark.parametrize("velocity_clamp", [(3, 2), (10, 8)])
 def test_vclamp_maxmin_exception(velocity_clamp, options, topology):
     """Tests if the max velocity_clamp is less than min velocity_clamp and
@@ -198,10 +184,6 @@ def test_vclamp_maxmin_exception(velocity_clamp, options, topology):
         GeneralOptimizerPSO(5, 2, velocity_clamp=velocity_clamp, options=options, topology=topology)
 
 
-@pytest.mark.parametrize(
-    "topology",
-    [Star(), Ring(), Pyramid(), Random()]
-)
 @pytest.mark.parametrize("err, center", [(IndexError, [1.5, 3.2, 2.5])])
 def test_center_exception(err, center, options, topology):
     """Tests if exception is thrown when center is not a list or of different shape"""
@@ -231,12 +213,9 @@ def test_training_history_shape(gbest_history, history, expected_shape):
     pso = vars(gbest_history)
     assert np.array(pso[history]).shape == expected_shape
 
-@pytest.mark.parametrize(
-    "topology",
-    [Star(), Ring(), Pyramid(), Random()]
-)
+
 def test_ftol_effect(options, topology):
-    """Test if setting the ftol breaks the optimization process accodingly"""
+    """Test if setting the ftol breaks the optimization process accordingly"""
     pso = GeneralOptimizerPSO(10, 2, options=options, topology=topology, ftol=1e-1)
     pso.optimize(sphere_func, 2000, verbose=0)
     assert np.array(pso.cost_history).shape != (2000,)


### PR DESCRIPTION
I cleaned up the code for the release of v0.3.0. The changes I made include:

- Set the `Star` topology to static and only assign the `neighbor_idx` attribute if it is not already assigned.
- Added the `VonNeumann `topology to the `GeneralOptimizer `with the necessary changes to the documentation and new exceptions for missing attributes.
- Added the `VonNeumann `topology to the `GeneralOptimizer `tests. The exceptions are tested and the topology fixture now also uses the `VonNeumann `class. Cleaned up the tests and added a static parametrization.
- Fixed a bug in the `Pyramid `topology where the optimize function of the `GeneralOptimizer `would output a `ValueError `because for some particles the neighbours were not computed. See also: #183 
- Changed the boundary for the connectivity of the particles in the `Pyramid `topology to be `swarm.dimensions + 1` instead of `5`. The reason for this change is that an `n`-dimensional simplex has `n+1`vertices.
- Ran `flake8`


See also: #183, #180 
Resolves: #183