### PR TITLE
Add configuration file for pyup

### DIFF
--- a/pyswarms/utils/.pyup.yml
+++ b/pyswarms/utils/.pyup.yml
@@ -1,0 +1,3 @@
+update: insecure
+branch: development
+schedule: "every month"


### PR DESCRIPTION
It seems that pyup is annoying. This commit fixes that. Instead of
spamming PRs everyday, it only creates relevant PRs per month. I've also
set the types of updates into "insecure." We will only update
dependencies that were found risky or vulnerable, no need to update
requirements whenever there is a new release.