### PR TITLE
Add stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,6 @@
+daysUntilStale: 30
+daysUntilClose: 3
+exemptLabels:
+    - admin
+exemptProjects: true
+staleLabel: stale


### PR DESCRIPTION
We should add stalebot to control and priorities Issues we have. It becomes paralyzing when we have
a lot of things to do and work on. Closing stale issues, and opening them when there's new activity, should atleast give us a breather to prioritize.