### PR TITLE
Changes made to basic_optimization.ipynb notebook for new API

### DIFF
--- a/examples/basic_optimization.ipynb
+++ b/examples/basic_optimization.ipynb
@@ -28,8 +28,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Running on Python version: 3.6.3 |Anaconda custom (64-bit)| (default, Oct 13 2017, 12:02:49) \n",
-      "[GCC 7.2.0]\n"
+      "Running on Python version: 3.6.7 (default, Oct 22 2018, 11:32:17) \n",
+      "[GCC 8.2.0]\n"
      ]
     }
    ],
@@ -86,29 +86,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:pyswarms.single.global_best:Iteration 1/1000, cost: 0.11075768527574707\n",
-      "INFO:pyswarms.single.global_best:Iteration 101/1000, cost: 7.521863508083004e-08\n",
-      "INFO:pyswarms.single.global_best:Iteration 201/1000, cost: 2.8159915186067273e-11\n",
-      "INFO:pyswarms.single.global_best:Iteration 301/1000, cost: 8.794923638889175e-17\n",
-      "INFO:pyswarms.single.global_best:Iteration 401/1000, cost: 1.4699516547190895e-21\n",
-      "INFO:pyswarms.single.global_best:Iteration 501/1000, cost: 5.111264897313781e-23\n",
-      "INFO:pyswarms.single.global_best:Iteration 601/1000, cost: 8.329697430155943e-27\n",
-      "INFO:pyswarms.single.global_best:Iteration 701/1000, cost: 1.662161785541961e-30\n",
-      "INFO:pyswarms.single.global_best:Iteration 801/1000, cost: 6.140424420222279e-34\n",
-      "INFO:pyswarms.single.global_best:Iteration 901/1000, cost: 2.0523902169204634e-39\n",
-      "INFO:pyswarms.single.global_best:================================\n",
-      "Optimization finished!\n",
-      "Final cost: 0.0000\n",
-      "Best value: [-2.431421462417008e-22, -9.502018378214418e-23]\n",
-      "\n"
+      "2019-01-30 03:39:00,994 - pyswarms.single.global_best - INFO - Optimize for 1000 iters with {'c1': 0.5, 'c2': 0.3, 'w': 0.9}\n",
+      "pyswarms.single.global_best: 100%|██████████|1000/1000, best_cost=8.82e-45\n",
+      "2019-01-30 03:39:16,037 - pyswarms.single.global_best - INFO - Optimization finished | best cost: 8.822594488832235e-45, best pos: [-2.75141304e-23 -8.98085025e-23]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 144 ms, sys: 14.8 ms, total: 159 ms\n",
-      "Wall time: 151 ms\n"
+      "CPU times: user 6.22 s, sys: 1.01 s, total: 7.23 s\n",
+      "Wall time: 15.1 s\n"
      ]
     }
    ],
@@ -121,7 +109,7 @@
     "optimizer = ps.single.GlobalBestPSO(n_particles=10, dimensions=2, options=options)\n",
     "\n",
     "# Perform optimization\n",
-    "cost, pos = optimizer.optimize(fx.sphere, print_step=100, iters=1000, verbose=3)"
+    "cost, pos = optimizer.optimize(fx.sphere, iters=1000)"
    ]
   },
   {
@@ -149,29 +137,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:pyswarms.single.local_best:Iteration 1/1000, cost: 0.01379181672220725\n",
-      "INFO:pyswarms.single.local_best:Iteration 101/1000, cost: 2.084056061999154e-07\n",
-      "INFO:pyswarms.single.local_best:Iteration 201/1000, cost: 9.44588224259351e-10\n",
-      "INFO:pyswarms.single.local_best:Iteration 301/1000, cost: 1.5414149511766008e-13\n",
-      "INFO:pyswarms.single.local_best:Iteration 401/1000, cost: 3.283944854760787e-16\n",
-      "INFO:pyswarms.single.local_best:Iteration 501/1000, cost: 2.093366830537641e-20\n",
-      "INFO:pyswarms.single.local_best:Iteration 601/1000, cost: 5.0279508047072096e-24\n",
-      "INFO:pyswarms.single.local_best:Iteration 701/1000, cost: 1.0492646748670006e-27\n",
-      "INFO:pyswarms.single.local_best:Iteration 801/1000, cost: 2.2616819643931453e-29\n",
-      "INFO:pyswarms.single.local_best:Iteration 901/1000, cost: 8.48269618909152e-35\n",
-      "INFO:pyswarms.single.local_best:================================\n",
-      "Optimization finished!\n",
-      "Final cost: 0.0000\n",
-      "Best value: [2.122881378865588e-18, -5.35447408455737e-19]\n",
-      "\n"
+      "2019-01-30 03:39:16,075 - pyswarms.single.local_best - INFO - Optimize for 1000 iters with {'c1': 0.5, 'c2': 0.3, 'w': 0.9, 'k': 2, 'p': 2}\n",
+      "pyswarms.single.local_best: 100%|██████████|1000/1000, best_cost=4.48e-43\n",
+      "2019-01-30 03:39:32,089 - pyswarms.single.local_best - INFO - Optimization finished | best cost: 4.476800323536992e-43, best pos: [-3.50747459e-22  3.87794395e-21]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 355 ms, sys: 4.36 ms, total: 359 ms\n",
-      "Wall time: 353 ms\n"
+      "CPU times: user 7.08 s, sys: 1.27 s, total: 8.35 s\n",
+      "Wall time: 16 s\n"
      ]
     }
    ],
@@ -184,7 +160,7 @@
     "optimizer = ps.single.LocalBestPSO(n_particles=10, dimensions=2, options=options)\n",
     "\n",
     "# Perform optimization\n",
-    "cost, pos = optimizer.optimize(fx.sphere, print_step=100, iters=1000, verbose=3)"
+    "cost, pos = optimizer.optimize(fx.sphere, iters=1000)"
    ]
   },
   {
@@ -234,29 +210,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:pyswarms.single.global_best:Iteration 1/1000, cost: 12.243865048066269\n",
-      "INFO:pyswarms.single.global_best:Iteration 101/1000, cost: 1.1759164022634394\n",
-      "INFO:pyswarms.single.global_best:Iteration 201/1000, cost: 0.9949603350768896\n",
-      "INFO:pyswarms.single.global_best:Iteration 301/1000, cost: 0.9949590581556009\n",
-      "INFO:pyswarms.single.global_best:Iteration 401/1000, cost: 0.9949590570934177\n",
-      "INFO:pyswarms.single.global_best:Iteration 501/1000, cost: 0.9949590570932898\n",
-      "INFO:pyswarms.single.global_best:Iteration 601/1000, cost: 0.9949590570932898\n",
-      "INFO:pyswarms.single.global_best:Iteration 701/1000, cost: 0.9949590570932898\n",
-      "INFO:pyswarms.single.global_best:Iteration 801/1000, cost: 0.9949590570932898\n",
-      "INFO:pyswarms.single.global_best:Iteration 901/1000, cost: 0.9949590570932898\n",
-      "INFO:pyswarms.single.global_best:================================\n",
-      "Optimization finished!\n",
-      "Final cost: 0.9950\n",
-      "Best value: [3.5850411183743393e-09, -0.9949586379966202]\n",
-      "\n"
+      "2019-01-30 03:39:32,224 - pyswarms.single.global_best - INFO - Optimize for 1000 iters with {'c1': 0.5, 'c2': 0.3, 'w': 0.9}\n",
+      "pyswarms.single.global_best: 100%|██████████|1000/1000, best_cost=0      \n",
+      "2019-01-30 03:39:47,829 - pyswarms.single.global_best - INFO - Optimization finished | best cost: 0.0, best pos: [-2.68381734e-09  3.05415115e-10]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 213 ms, sys: 7.55 ms, total: 221 ms\n",
-      "Wall time: 210 ms\n"
+      "CPU times: user 6.76 s, sys: 1.14 s, total: 7.9 s\n",
+      "Wall time: 15.6 s\n"
      ]
     }
    ],
@@ -269,15 +233,8 @@
     "optimizer = ps.single.GlobalBestPSO(n_particles=10, dimensions=2, options=options, bounds=bounds)\n",
     "\n",
     "# Perform optimization\n",
-    "cost, pos = optimizer.optimize(fx.rastrigin, print_step=100, iters=1000, verbose=3)"
+    "cost, pos = optimizer.optimize(fx.rastrigin, iters=1000)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -295,15 +252,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Running Python 3.5.2 |Anaconda custom (64-bit)| (default, Jul  2 2016, 17:53:06) \n",
-      "[GCC 4.4.7 20120313 (Red Hat 4.4.7-1)]\n"
+      "Running Python 3.6.7 (default, Oct 22 2018, 11:32:17) \n",
+      "[GCC 8.2.0]\n"
      ]
     }
    ],
@@ -317,7 +274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {
     "scrolled": true
    },
@@ -349,29 +306,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:pyswarms.single.global_best:Arguments Passed to Objective Function: {'c': 0, 'b': 100, 'a': 1}\n",
-      "INFO:pyswarms.single.global_best:Iteration 1/1000, cost: 1022.9667801907804\n",
-      "INFO:pyswarms.single.global_best:Iteration 101/1000, cost: 0.0011172801146408992\n",
-      "INFO:pyswarms.single.global_best:Iteration 201/1000, cost: 7.845605970774126e-07\n",
-      "INFO:pyswarms.single.global_best:Iteration 301/1000, cost: 1.313503109901238e-09\n",
-      "INFO:pyswarms.single.global_best:Iteration 401/1000, cost: 5.187079604907219e-10\n",
-      "INFO:pyswarms.single.global_best:Iteration 501/1000, cost: 1.0115283486088853e-10\n",
-      "INFO:pyswarms.single.global_best:Iteration 601/1000, cost: 2.329870757208421e-13\n",
-      "INFO:pyswarms.single.global_best:Iteration 701/1000, cost: 4.826176894160183e-15\n",
-      "INFO:pyswarms.single.global_best:Iteration 801/1000, cost: 3.125715456651088e-17\n",
-      "INFO:pyswarms.single.global_best:Iteration 901/1000, cost: 1.4236768129666014e-19\n",
-      "INFO:pyswarms.single.global_best:================================\n",
-      "Optimization finished!\n",
-      "Final cost: 0.0000\n",
-      "Best value: [0.99999999996210465, 0.9999999999218413]\n",
-      "\n"
+      "2019-01-30 03:39:48,154 - pyswarms.single.global_best - INFO - Optimize for 1000 iters with {'c1': 0.5, 'c2': 0.3, 'w': 0.9}\n",
+      "pyswarms.single.global_best: 100%|██████████|1000/1000, best_cost=3.18e-26\n",
+      "2019-01-30 03:40:04,073 - pyswarms.single.global_best - INFO - Optimization finished | best cost: 3.180199062166014e-26, best pos: [1. 1.]\n"
      ]
     }
    ],
@@ -387,7 +331,7 @@
     "\n",
     "# now run the optimization, pass a=1 and b=100 as a tuple assigned to args\n",
     "\n",
-    "cost, pos = optimizer.optimize(rosenbrock_with_args, 1000, print_step=100, verbose=3, a=1, b=100, c=0)"
+    "cost, pos = optimizer.optimize(rosenbrock_with_args, 1000, a=1, b=100, c=0)"
    ]
   },
   {
@@ -399,35 +343,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:pyswarms.single.global_best:Arguments Passed to Objective Function: {'c': 0, 'b': 100.0, 'a': 1.0}\n",
-      "INFO:pyswarms.single.global_best:Iteration 1/1000, cost: 1.996797703363527e-21\n",
-      "INFO:pyswarms.single.global_best:Iteration 101/1000, cost: 1.0061676299213387e-24\n",
-      "INFO:pyswarms.single.global_best:Iteration 201/1000, cost: 4.8140236741112245e-28\n",
-      "INFO:pyswarms.single.global_best:Iteration 301/1000, cost: 2.879342304056693e-29\n",
-      "INFO:pyswarms.single.global_best:Iteration 401/1000, cost: 0.0\n",
-      "INFO:pyswarms.single.global_best:Iteration 501/1000, cost: 0.0\n",
-      "INFO:pyswarms.single.global_best:Iteration 601/1000, cost: 0.0\n",
-      "INFO:pyswarms.single.global_best:Iteration 701/1000, cost: 0.0\n",
-      "INFO:pyswarms.single.global_best:Iteration 801/1000, cost: 0.0\n",
-      "INFO:pyswarms.single.global_best:Iteration 901/1000, cost: 0.0\n",
-      "INFO:pyswarms.single.global_best:================================\n",
-      "Optimization finished!\n",
-      "Final cost: 0.0000\n",
-      "Best value: [1.0, 1.0]\n",
-      "\n"
+      "2019-01-30 03:40:04,104 - pyswarms.single.global_best - INFO - Optimize for 1000 iters with {'c1': 0.5, 'c2': 0.3, 'w': 0.9}\n",
+      "pyswarms.single.global_best: 100%|██████████|1000/1000, best_cost=0      \n",
+      "2019-01-30 03:40:19,379 - pyswarms.single.global_best - INFO - Optimization finished | best cost: 0.0, best pos: [1. 1.]\n"
      ]
     }
    ],
    "source": [
     "kwargs={\"a\": 1.0, \"b\": 100.0, 'c':0}\n",
-    "cost, pos = optimizer.optimize(rosenbrock_with_args, 1000, print_step=100, verbose=3, **kwargs)"
+    "cost, pos = optimizer.optimize(rosenbrock_with_args, 1000, **kwargs)"
    ]
   },
   {
@@ -441,44 +372,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:pyswarms.single.global_best:Arguments Passed to Objective Function: {'b': 100, 'a': 1}\n",
-      "INFO:pyswarms.single.global_best:Iteration 1/1000, cost: 0.0\n",
-      "INFO:pyswarms.single.global_best:Iteration 101/1000, cost: 0.0\n",
-      "INFO:pyswarms.single.global_best:Iteration 201/1000, cost: 0.0\n",
-      "INFO:pyswarms.single.global_best:Iteration 301/1000, cost: 0.0\n",
-      "INFO:pyswarms.single.global_best:Iteration 401/1000, cost: 0.0\n",
-      "INFO:pyswarms.single.global_best:Iteration 501/1000, cost: 0.0\n",
-      "INFO:pyswarms.single.global_best:Iteration 601/1000, cost: 0.0\n",
-      "INFO:pyswarms.single.global_best:Iteration 701/1000, cost: 0.0\n",
-      "INFO:pyswarms.single.global_best:Iteration 801/1000, cost: 0.0\n",
-      "INFO:pyswarms.single.global_best:Iteration 901/1000, cost: 0.0\n",
-      "INFO:pyswarms.single.global_best:================================\n",
-      "Optimization finished!\n",
-      "Final cost: 0.0000\n",
-      "Best value: [1.0, 1.0]\n",
-      "\n"
+      "2019-01-30 03:40:19,414 - pyswarms.single.global_best - INFO - Optimize for 1000 iters with {'c1': 0.5, 'c2': 0.3, 'w': 0.9}\n",
+      "pyswarms.single.global_best: 100%|██████████|1000/1000, best_cost=0\n",
+      "2019-01-30 03:40:34,629 - pyswarms.single.global_best - INFO - Optimization finished | best cost: 0.0, best pos: [1. 1.]\n"
      ]
     }
    ],
    "source": [
-    "cost, pos = optimizer.optimize(rosenbrock_with_args, 1000, print_step=100, verbose=3, a=1, b=100)"
+    "cost, pos = optimizer.optimize(rosenbrock_with_args, 1000, a=1, b=100)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -498,7 +407,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/examples/basic_optimization.ipynb
+++ b/examples/basic_optimization.ipynb
@@ -86,17 +86,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2019-01-30 03:39:00,994 - pyswarms.single.global_best - INFO - Optimize for 1000 iters with {'c1': 0.5, 'c2': 0.3, 'w': 0.9}\n",
-      "pyswarms.single.global_best: 100%|██████████|1000/1000, best_cost=8.82e-45\n",
-      "2019-01-30 03:39:16,037 - pyswarms.single.global_best - INFO - Optimization finished | best cost: 8.822594488832235e-45, best pos: [-2.75141304e-23 -8.98085025e-23]\n"
+      "2019-01-30 04:23:31,846 - pyswarms.single.global_best - INFO - Optimize for 1000 iters with {'c1': 0.5, 'c2': 0.3, 'w': 0.9}\n",
+      "pyswarms.single.global_best: 100%|██████████|1000/1000, best_cost=5.34e-43\n",
+      "2019-01-30 04:23:46,631 - pyswarms.single.global_best - INFO - Optimization finished | best cost: 5.3409429804817095e-43, best pos: [-4.84855366e-22 -5.46817677e-22]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 6.22 s, sys: 1.01 s, total: 7.23 s\n",
-      "Wall time: 15.1 s\n"
+      "CPU times: user 5.63 s, sys: 916 ms, total: 6.55 s\n",
+      "Wall time: 14.8 s\n"
      ]
     }
    ],
@@ -137,17 +137,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2019-01-30 03:39:16,075 - pyswarms.single.local_best - INFO - Optimize for 1000 iters with {'c1': 0.5, 'c2': 0.3, 'w': 0.9, 'k': 2, 'p': 2}\n",
-      "pyswarms.single.local_best: 100%|██████████|1000/1000, best_cost=4.48e-43\n",
-      "2019-01-30 03:39:32,089 - pyswarms.single.local_best - INFO - Optimization finished | best cost: 4.476800323536992e-43, best pos: [-3.50747459e-22  3.87794395e-21]\n"
+      "2019-01-30 04:23:46,672 - pyswarms.single.local_best - INFO - Optimize for 1000 iters with {'c1': 0.5, 'c2': 0.3, 'w': 0.9, 'k': 2, 'p': 2}\n",
+      "pyswarms.single.local_best: 100%|██████████|1000/1000, best_cost=1.19e-48\n",
+      "2019-01-30 04:24:02,254 - pyswarms.single.local_best - INFO - Optimization finished | best cost: 1.1858559943008184e-48, best pos: [5.47013119e-24 7.95177208e-25]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 7.08 s, sys: 1.27 s, total: 8.35 s\n",
-      "Wall time: 16 s\n"
+      "CPU times: user 6.63 s, sys: 1.04 s, total: 7.68 s\n",
+      "Wall time: 15.6 s\n"
      ]
     }
    ],
@@ -210,17 +210,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2019-01-30 03:39:32,224 - pyswarms.single.global_best - INFO - Optimize for 1000 iters with {'c1': 0.5, 'c2': 0.3, 'w': 0.9}\n",
+      "2019-01-30 04:24:02,463 - pyswarms.single.global_best - INFO - Optimize for 1000 iters with {'c1': 0.5, 'c2': 0.3, 'w': 0.9}\n",
       "pyswarms.single.global_best: 100%|██████████|1000/1000, best_cost=0      \n",
-      "2019-01-30 03:39:47,829 - pyswarms.single.global_best - INFO - Optimization finished | best cost: 0.0, best pos: [-2.68381734e-09  3.05415115e-10]\n"
+      "2019-01-30 04:24:17,995 - pyswarms.single.global_best - INFO - Optimization finished | best cost: 0.0, best pos: [1.99965504e-09 9.50602717e-10]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 6.76 s, sys: 1.14 s, total: 7.9 s\n",
-      "Wall time: 15.6 s\n"
+      "CPU times: user 6.74 s, sys: 1.01 s, total: 7.75 s\n",
+      "Wall time: 15.5 s\n"
      ]
     }
    ],
@@ -313,9 +313,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2019-01-30 03:39:48,154 - pyswarms.single.global_best - INFO - Optimize for 1000 iters with {'c1': 0.5, 'c2': 0.3, 'w': 0.9}\n",
-      "pyswarms.single.global_best: 100%|██████████|1000/1000, best_cost=3.18e-26\n",
-      "2019-01-30 03:40:04,073 - pyswarms.single.global_best - INFO - Optimization finished | best cost: 3.180199062166014e-26, best pos: [1. 1.]\n"
+      "2019-01-30 04:24:18,385 - pyswarms.single.global_best - INFO - Optimize for 1000 iters with {'c1': 0.5, 'c2': 0.3, 'w': 0.9}\n",
+      "pyswarms.single.global_best: 100%|██████████|1000/1000, best_cost=1.65e-18\n",
+      "2019-01-30 04:24:33,873 - pyswarms.single.global_best - INFO - Optimization finished | best cost: 1.6536536065757395e-18, best pos: [1. 1.]\n"
      ]
     }
    ],
@@ -350,9 +350,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2019-01-30 03:40:04,104 - pyswarms.single.global_best - INFO - Optimize for 1000 iters with {'c1': 0.5, 'c2': 0.3, 'w': 0.9}\n",
-      "pyswarms.single.global_best: 100%|██████████|1000/1000, best_cost=0      \n",
-      "2019-01-30 03:40:19,379 - pyswarms.single.global_best - INFO - Optimization finished | best cost: 0.0, best pos: [1. 1.]\n"
+      "2019-01-30 04:24:33,904 - pyswarms.single.global_best - INFO - Optimize for 1000 iters with {'c1': 0.5, 'c2': 0.3, 'w': 0.9}\n",
+      "pyswarms.single.global_best: 100%|██████████|1000/1000, best_cost=9.13e-19\n",
+      "2019-01-30 04:24:49,482 - pyswarms.single.global_best - INFO - Optimization finished | best cost: 9.132114249459913e-19, best pos: [1. 1.]\n"
      ]
     }
    ],
@@ -379,9 +379,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2019-01-30 03:40:19,414 - pyswarms.single.global_best - INFO - Optimize for 1000 iters with {'c1': 0.5, 'c2': 0.3, 'w': 0.9}\n",
-      "pyswarms.single.global_best: 100%|██████████|1000/1000, best_cost=0\n",
-      "2019-01-30 03:40:34,629 - pyswarms.single.global_best - INFO - Optimization finished | best cost: 0.0, best pos: [1. 1.]\n"
+      "2019-01-30 04:24:49,518 - pyswarms.single.global_best - INFO - Optimize for 1000 iters with {'c1': 0.5, 'c2': 0.3, 'w': 0.9}\n",
+      "pyswarms.single.global_best: 100%|██████████|1000/1000, best_cost=9.13e-19\n",
+      "2019-01-30 04:25:05,071 - pyswarms.single.global_best - INFO - Optimization finished | best cost: 9.125748012380431e-19, best pos: [1. 1.]\n"
      ]
     }
    ],

--- a/examples/custom_optimization_loop.ipynb
+++ b/examples/custom_optimization_loop.ipynb
@@ -41,8 +41,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Running on Python version: 3.6.3 |Anaconda custom (64-bit)| (default, Oct 13 2017, 12:02:49) \n",
-      "[GCC 7.2.0]\n"
+      "Running on Python version: 3.6.7 (default, Oct 22 2018, 11:32:17) \n",
+      "[GCC 8.2.0]\n"
      ]
     }
    ],
@@ -139,13 +139,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Iteration: 1 | my_swarm.best_cost: 0.0180\n",
-      "Iteration: 21 | my_swarm.best_cost: 0.0023\n",
-      "Iteration: 41 | my_swarm.best_cost: 0.0021\n",
-      "Iteration: 61 | my_swarm.best_cost: 0.0021\n",
-      "Iteration: 81 | my_swarm.best_cost: 0.0021\n",
-      "The best cost found by our swarm is: 0.0021\n",
-      "The best position found by our swarm is: [0.03904002 0.02444573]\n"
+      "Iteration: 1 | my_swarm.best_cost: 0.0020\n",
+      "Iteration: 21 | my_swarm.best_cost: 0.0000\n",
+      "Iteration: 41 | my_swarm.best_cost: 0.0000\n",
+      "Iteration: 61 | my_swarm.best_cost: 0.0000\n",
+      "Iteration: 81 | my_swarm.best_cost: 0.0000\n",
+      "The best cost found by our swarm is: 0.0000\n",
+      "The best position found by our swarm is: [ 1.26773865e-17 -1.24781239e-18]\n"
      ]
     }
    ],
@@ -191,22 +191,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:pyswarms.single.global_best:Iteration 1/100, cost: 0.025649680624878678\n",
-      "INFO:pyswarms.single.global_best:Iteration 21/100, cost: 0.00011046719760866999\n",
-      "INFO:pyswarms.single.global_best:Iteration 41/100, cost: 7.472715087706944e-05\n",
-      "INFO:pyswarms.single.global_best:Iteration 61/100, cost: 7.457131875962127e-05\n",
-      "INFO:pyswarms.single.global_best:Iteration 81/100, cost: 7.457043431658092e-05\n",
-      "INFO:pyswarms.single.global_best:================================\n",
-      "Optimization finished!\n",
-      "Final cost: 0.0001\n",
-      "Best value: [0.007417861777661566, 0.004421058167808941]\n",
-      "\n"
+      "2019-01-30 23:50:06,728 - pyswarms.single.global_best - INFO - Optimize for 100 iters with {'c1': 0.6, 'c2': 0.3, 'w': 0.4}\n",
+      "pyswarms.single.global_best: 100%|██████████|100/100, best_cost=0.00293\n",
+      "2019-01-30 23:50:08,269 - pyswarms.single.global_best - INFO - Optimization finished | best cost: 0.0029270203924585485, best pos: [0.0497835  0.02118073]\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "(7.457042867564255e-05, array([0.00741786, 0.00442106]))"
+       "(0.0029270203924585485, array([0.0497835 , 0.02118073]))"
       ]
      },
      "execution_count": 6,
@@ -218,15 +211,8 @@
     "from pyswarms.single import GlobalBestPSO\n",
     "\n",
     "optimizer = GlobalBestPSO(n_particles=50, dimensions=2, options=my_options) # Reuse our previous options\n",
-    "optimizer.optimize(f, iters=100, print_step=20, verbose=2)"
+    "optimizer.optimize(f, iters=100)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -245,7 +231,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- wherever the single_obj.sphere function is called, only `iter` argument is given, arguments `print_step` and `verbose` are removed.


## Motivation and Context
If this checks out I will make similar changes to other notebooks. Since I am a first-timer I am just changing one file to make sure I am doing it right.

