### PR TITLE
BinaryPSO should return final best position instead of final swarm

### DIFF
--- a/pyswarms/discrete/binary.py
+++ b/pyswarms/discrete/binary.py
@@ -207,7 +207,7 @@ class BinaryPSO(DiscreteSwarmOptimizer):
             self.swarm.position = self._compute_position(self.swarm)
         # Obtain the final best_cost and the final best_position
         final_best_cost = self.swarm.best_cost.copy()
-        final_best_pos = self.swarm.best_pos.copy()
+        final_best_pos = self.swarm.position[self.swarm.pbest_cost.argmin(axis=0)].copy()
         self.rep.log(
             "Optimization finished | best cost: {}, best pos: {}".format(
                 final_best_cost, final_best_pos


### PR DESCRIPTION
Resolves #292

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The binary optimizer returns the entire final swarm instead of the final best position.

I think this happens because in the return stage of the optimize() function, we are copying self.swarm.best_pos which is an array (n_dimensions, particles), instead of the position of the best particle.

The expected behavior is implemented in local_best.py.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#292 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Ran tests locally
2. Example notebook (feature_selection)
3. Personal project 

## Screenshots (if appropriate):
See #292 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

