### PR TITLE
Removed non-feature "fast" flag from optimizers

### DIFF
--- a/pyswarms/base/base_discrete.py
+++ b/pyswarms/base/base_discrete.py
@@ -129,7 +129,7 @@ class DiscreteSwarmOptimizer(abc.ABC):
         self.velocity_history.append(hist.velocity)
 
     @abc.abstractmethod
-    def optimize(self, objective_func, iters, fast=False, **kwargs):
+    def optimize(self, objective_func, iters, **kwargs):
         """Optimize the swarm for a number of iterations
 
         Performs the optimization to evaluate the objective
@@ -142,8 +142,6 @@ class DiscreteSwarmOptimizer(abc.ABC):
             objective function to be evaluated
         iters : int
             number of iterations
-        fast : bool (default is False)
-            if True, time.sleep is not executed
         kwargs : dict
             arguments for objective function
 

--- a/pyswarms/base/base_single.py
+++ b/pyswarms/base/base_single.py
@@ -129,7 +129,7 @@ class SwarmOptimizer(abc.ABC):
         self.velocity_history.append(hist.velocity)
 
     @abc.abstractmethod
-    def optimize(self, objective_func, iters, fast=False, **kwargs):
+    def optimize(self, objective_func, iters, **kwargs):
         """Optimize the swarm for a number of iterations
 
         Performs the optimization to evaluate the objective
@@ -142,8 +142,6 @@ class SwarmOptimizer(abc.ABC):
             objective function to be evaluated
         iters : int
             number of iterations
-        fast : bool (default is False)
-            if True, time.sleep is not executed
         kwargs : dict
             arguments for objective function
 

--- a/pyswarms/discrete/binary.py
+++ b/pyswarms/discrete/binary.py
@@ -53,7 +53,6 @@ R.C. Eberhart in Particle Swarm Optimization [SMC1997]_.
 
 # Import standard library
 import logging
-from time import sleep
 
 # Import modules
 import numpy as np
@@ -135,7 +134,7 @@ class BinaryPSO(DiscreteSwarmOptimizer):
         self.vh = VelocityHandler(strategy=vh_strategy)
         self.name = __name__
 
-    def optimize(self, objective_func, iters, fast=False, **kwargs):
+    def optimize(self, objective_func, iters, **kwargs):
         """Optimize the swarm for a number of iterations
 
         Performs the optimization to evaluate the objective
@@ -147,8 +146,6 @@ class BinaryPSO(DiscreteSwarmOptimizer):
             objective function to be evaluated
         iters : int
             number of iterations
-        fast : bool (default is False)
-            if True, time.sleep is not executed
         kwargs : dict
             arguments for objective function
 
@@ -168,8 +165,6 @@ class BinaryPSO(DiscreteSwarmOptimizer):
 
         self.swarm.pbest_cost = np.full(self.swarm_size[0], np.inf)
         for i in self.rep.pbar(iters, self.name):
-            if not fast:
-                sleep(0.01)
             # Compute cost for current position and personal best
             self.swarm.current_cost = objective_func(
                 self.swarm.position, **kwargs

--- a/pyswarms/single/general_optimizer.py
+++ b/pyswarms/single/general_optimizer.py
@@ -58,7 +58,6 @@ R.C. Eberhart in Particle Swarm Optimization [IJCNN1995]_.
 
 # Import standard library
 import logging
-from time import sleep
 
 # Import modules
 import numpy as np
@@ -181,7 +180,7 @@ class GeneralOptimizerPSO(SwarmOptimizer):
         self.vh = VelocityHandler(strategy=vh_strategy)
         self.name = __name__
 
-    def optimize(self, objective_func, iters, fast=False, **kwargs):
+    def optimize(self, objective_func, iters, **kwargs):
         """Optimize the swarm for a number of iterations
 
         Performs the optimization to evaluate the objective
@@ -193,8 +192,6 @@ class GeneralOptimizerPSO(SwarmOptimizer):
             objective function to be evaluated
         iters : int
             number of iterations
-        fast : bool (default is False)
-            if True, time.sleep is not executed
         kwargs : dict
             arguments for the objective function
 
@@ -203,9 +200,6 @@ class GeneralOptimizerPSO(SwarmOptimizer):
         tuple
             the global best cost and the global best position.
         """
-        if not fast:
-            sleep(0.01)
-
         self.rep.log("Obj. func. args: {}".format(kwargs), lvl=logging.DEBUG)
         self.rep.log(
             "Optimize for {} iters with {}".format(iters, self.options),

--- a/pyswarms/single/global_best.py
+++ b/pyswarms/single/global_best.py
@@ -57,7 +57,6 @@ R.C. Eberhart in Particle Swarm Optimization [IJCNN1995]_.
 
 # Import standard library
 import logging
-from time import sleep
 
 # Import modules
 import numpy as np
@@ -142,7 +141,7 @@ class GlobalBestPSO(SwarmOptimizer):
         self.vh = VelocityHandler(strategy=vh_strategy)
         self.name = __name__
 
-    def optimize(self, objective_func, iters, fast=False, **kwargs):
+    def optimize(self, objective_func, iters, **kwargs):
         """Optimize the swarm for a number of iterations
 
         Performs the optimization to evaluate the objective
@@ -154,8 +153,6 @@ class GlobalBestPSO(SwarmOptimizer):
             objective function to be evaluated
         iters : int
             number of iterations
-        fast : bool (default is False)
-            if True, time.sleep is not executed
         kwargs : dict
             arguments for the objective function
 
@@ -176,8 +173,6 @@ class GlobalBestPSO(SwarmOptimizer):
 
         self.swarm.pbest_cost = np.full(self.swarm_size[0], np.inf)
         for i in self.rep.pbar(iters, self.name):
-            if not fast:
-                sleep(0.01)
             # Compute cost for current position and personal best
             # fmt: off
             self.swarm.current_cost = objective_func(self.swarm.position, **kwargs)

--- a/pyswarms/single/local_best.py
+++ b/pyswarms/single/local_best.py
@@ -66,7 +66,6 @@ J. Kennedy and R.C. Eberhart in Particle Swarm Optimization
 
 # Import standard library
 import logging
-from time import sleep
 
 # Import modules
 import numpy as np
@@ -166,7 +165,7 @@ class LocalBestPSO(SwarmOptimizer):
         self.vh = VelocityHandler(strategy=vh_strategy)
         self.name = __name__
 
-    def optimize(self, objective_func, iters, fast=False, **kwargs):
+    def optimize(self, objective_func, iters, **kwargs):
         """Optimize the swarm for a number of iterations
 
         Performs the optimization to evaluate the objective
@@ -178,8 +177,6 @@ class LocalBestPSO(SwarmOptimizer):
             objective function to be evaluated
         iters : int
             number of iterations
-        fast : bool (default is False)
-            if True, time.sleep is not executed
         kwargs : dict
             arguments for the objective function
 
@@ -200,8 +197,6 @@ class LocalBestPSO(SwarmOptimizer):
 
         self.swarm.pbest_cost = np.full(self.swarm_size[0], np.inf)
         for i in self.rep.pbar(iters, self.name):
-            if not fast:
-                sleep(0.01)
             # Compute cost for current position and personal best
             self.swarm.current_cost = objective_func(
                 self.swarm.position, **kwargs


### PR DESCRIPTION
Resolves #303

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed non-feature "fast" flag from optimizers:
- Updated function definitions
- Updated docstrings
- Removed `time.sleep` usages

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#303 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Discussed in #303.
All optimizers have an unnecessary optional argument `fast` whose default value makes the optimizers call `time.sleep` at the start of each iteration. 

This is a non-feature and was only introduced to try to make `tqdm` progress bars look nice 😄

A cool side-effect of this PR is that the tests run faster now since a lot of test cases use an optimizer with 1000 iterations (= 10 secs sleeping 💤).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran test suite locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

