### PR TITLE
Support parallel particle evaluation

### DIFF
--- a/pyswarms/base/base_discrete.py
+++ b/pyswarms/base/base_discrete.py
@@ -129,7 +129,7 @@ class DiscreteSwarmOptimizer(abc.ABC):
         self.velocity_history.append(hist.velocity)
 
     @abc.abstractmethod
-    def optimize(self, objective_func, iters, **kwargs):
+    def optimize(self, objective_func, iters, n_processes=None, **kwargs):
         """Optimize the swarm for a number of iterations
 
         Performs the optimization to evaluate the objective
@@ -142,6 +142,8 @@ class DiscreteSwarmOptimizer(abc.ABC):
             objective function to be evaluated
         iters : int
             number of iterations
+        n_processes : int
+            number of processes to use for parallel particle evaluation (default: None = no parallelization)
         kwargs : dict
             arguments for objective function
 

--- a/pyswarms/base/base_single.py
+++ b/pyswarms/base/base_single.py
@@ -129,7 +129,7 @@ class SwarmOptimizer(abc.ABC):
         self.velocity_history.append(hist.velocity)
 
     @abc.abstractmethod
-    def optimize(self, objective_func, iters, **kwargs):
+    def optimize(self, objective_func, iters, n_processes=None, **kwargs):
         """Optimize the swarm for a number of iterations
 
         Performs the optimization to evaluate the objective
@@ -142,6 +142,8 @@ class SwarmOptimizer(abc.ABC):
             objective function to be evaluated
         iters : int
             number of iterations
+        n_processes : int
+            number of processes to use for parallel particle evaluation (default: None = no parallelization)
         kwargs : dict
             arguments for objective function
 

--- a/pyswarms/discrete/binary.py
+++ b/pyswarms/discrete/binary.py
@@ -56,8 +56,9 @@ import logging
 
 # Import modules
 import numpy as np
+import multiprocessing as mp
 
-from ..backend.operators import compute_pbest
+from ..backend.operators import compute_pbest, compute_objective_function
 from ..backend.topology import Ring
 from ..backend.handlers import BoundaryHandler, VelocityHandler
 from ..base import DiscreteSwarmOptimizer
@@ -134,7 +135,7 @@ class BinaryPSO(DiscreteSwarmOptimizer):
         self.vh = VelocityHandler(strategy=vh_strategy)
         self.name = __name__
 
-    def optimize(self, objective_func, iters, **kwargs):
+    def optimize(self, objective_func, iters, n_processes=None, **kwargs):
         """Optimize the swarm for a number of iterations
 
         Performs the optimization to evaluate the objective
@@ -146,6 +147,8 @@ class BinaryPSO(DiscreteSwarmOptimizer):
             objective function to be evaluated
         iters : int
             number of iterations
+        n_processes : int
+            number of processes to use for parallel particle evaluation (default: None = no parallelization)
         kwargs : dict
             arguments for objective function
 
@@ -163,11 +166,14 @@ class BinaryPSO(DiscreteSwarmOptimizer):
         # Populate memory of the handlers
         self.vh.memory = self.swarm.position
 
+        # Setup Pool of processes for parallel evaluation
+        pool = None if n_processes is None else mp.Pool(n_processes)
+
         self.swarm.pbest_cost = np.full(self.swarm_size[0], np.inf)
         for i in self.rep.pbar(iters, self.name):
             # Compute cost for current position and personal best
-            self.swarm.current_cost = objective_func(
-                self.swarm.position, **kwargs
+            self.swarm.current_cost = compute_objective_function(
+                self.swarm, objective_func, pool, **kwargs
             )
             self.swarm.pbest_pos, self.swarm.pbest_cost = compute_pbest(
                 self.swarm

--- a/pyswarms/single/general_optimizer.py
+++ b/pyswarms/single/general_optimizer.py
@@ -61,8 +61,9 @@ import logging
 
 # Import modules
 import numpy as np
+import multiprocessing as mp
 
-from ..backend.operators import compute_pbest
+from ..backend.operators import compute_pbest, compute_objective_function
 from ..backend.topology import Topology
 from ..backend.handlers import BoundaryHandler, VelocityHandler
 from ..base import SwarmOptimizer
@@ -180,7 +181,7 @@ class GeneralOptimizerPSO(SwarmOptimizer):
         self.vh = VelocityHandler(strategy=vh_strategy)
         self.name = __name__
 
-    def optimize(self, objective_func, iters, **kwargs):
+    def optimize(self, objective_func, iters, n_processes=None, **kwargs):
         """Optimize the swarm for a number of iterations
 
         Performs the optimization to evaluate the objective
@@ -192,6 +193,8 @@ class GeneralOptimizerPSO(SwarmOptimizer):
             objective function to be evaluated
         iters : int
             number of iterations
+        n_processes : int
+            number of processes to use for parallel particle evaluation (default: None = no parallelization)
         kwargs : dict
             arguments for the objective function
 
@@ -210,11 +213,14 @@ class GeneralOptimizerPSO(SwarmOptimizer):
         self.bh.memory = self.swarm.position
         self.vh.memory = self.swarm.position
 
+        # Setup Pool of processes for parallel evaluation
+        pool = None if n_processes is None else mp.Pool(n_processes)
+
         self.swarm.pbest_cost = np.full(self.swarm_size[0], np.inf)
         for i in self.rep.pbar(iters, self.name):
             # Compute cost for current position and personal best
             # fmt: off
-            self.swarm.current_cost = objective_func(self.swarm.position, **kwargs)
+            self.swarm.current_cost = compute_objective_function(self.swarm, objective_func, pool=pool, **kwargs)
             self.swarm.pbest_pos, self.swarm.pbest_cost = compute_pbest(self.swarm)
             best_cost_yet_found = self.swarm.best_cost
             # fmt: on

--- a/pyswarms/single/global_best.py
+++ b/pyswarms/single/global_best.py
@@ -60,8 +60,9 @@ import logging
 
 # Import modules
 import numpy as np
+import multiprocessing as mp
 
-from ..backend.operators import compute_pbest
+from ..backend.operators import compute_pbest, compute_objective_function
 from ..backend.topology import Star
 from ..backend.handlers import BoundaryHandler, VelocityHandler
 from ..base import SwarmOptimizer
@@ -141,7 +142,7 @@ class GlobalBestPSO(SwarmOptimizer):
         self.vh = VelocityHandler(strategy=vh_strategy)
         self.name = __name__
 
-    def optimize(self, objective_func, iters, **kwargs):
+    def optimize(self, objective_func, iters, n_processes=None, **kwargs):
         """Optimize the swarm for a number of iterations
 
         Performs the optimization to evaluate the objective
@@ -153,6 +154,8 @@ class GlobalBestPSO(SwarmOptimizer):
             objective function to be evaluated
         iters : int
             number of iterations
+        n_processes : int
+            number of processes to use for parallel particle evaluation (default: None = no parallelization)
         kwargs : dict
             arguments for the objective function
 
@@ -171,11 +174,14 @@ class GlobalBestPSO(SwarmOptimizer):
         self.bh.memory = self.swarm.position
         self.vh.memory = self.swarm.position
 
+        # Setup Pool of processes for parallel evaluation
+        pool = None if n_processes is None else mp.Pool(n_processes)
+
         self.swarm.pbest_cost = np.full(self.swarm_size[0], np.inf)
         for i in self.rep.pbar(iters, self.name):
             # Compute cost for current position and personal best
             # fmt: off
-            self.swarm.current_cost = objective_func(self.swarm.position, **kwargs)
+            self.swarm.current_cost = compute_objective_function(self.swarm, objective_func, pool=pool, **kwargs)
             self.swarm.pbest_pos, self.swarm.pbest_cost = compute_pbest(self.swarm)
             # Set best_cost_yet_found for ftol
             best_cost_yet_found = self.swarm.best_cost

--- a/pyswarms/utils/decorators/decorators.py
+++ b/pyswarms/utils/decorators/decorators.py
@@ -1,5 +1,6 @@
 # Import modules
 import numpy as np
+from functools import wraps
 
 
 def cost(cost_func):
@@ -39,6 +40,7 @@ def cost(cost_func):
         The vectorized output for all particles as defined by :code:`cost_func`
     """
 
+    @wraps(cost_func)
     def cost_dec(particles, **kwargs):
         n_particles = particles.shape[0]
         vector = np.array(

--- a/tests/optimizers/abc_test_optimizer.py
+++ b/tests/optimizers/abc_test_optimizer.py
@@ -83,6 +83,13 @@ class ABCTestOptimizer(abc.ABC):
         opt.optimize(sphere, 2000)
         assert np.array(opt.cost_history).shape != (2000,)
 
+    def test_parallel_evaluation(self, obj_without_args, optimizer, options):
+        """Test if parallelization breaks the optimization process"""
+        import multiprocessing
+        opt = optimizer(100, 2, options=options)
+        opt.optimize(obj_without_args, 2000, n_processes=multiprocessing.cpu_count())
+        assert np.array(opt.cost_history).shape == (2000,)
+
     def test_obj_with_kwargs(self, obj_with_args, optimizer, options):
         """Test if kwargs are passed properly in objfunc"""
         x_max = 10 * np.ones(2)

--- a/tests/optimizers/test_general_optimizer.py
+++ b/tests/optimizers/test_general_optimizer.py
@@ -70,6 +70,12 @@ class TestGeneralOptimizer(ABCTestOptimizer):
         optimizer.optimize(sphere, 2000)
         assert np.array(optimizer.cost_history).shape != (2000,)
 
+    def test_parallel_evaluation(self, obj_without_args, optimizer):
+        """Test if parallelization breaks the optimization process"""
+        import multiprocessing
+        optimizer.optimize(obj_without_args, 2000, n_processes=multiprocessing.cpu_count())
+        assert np.array(optimizer.cost_history).shape == (2000,)
+
     @pytest.mark.skip(reason="Some topologies converge too slowly")
     def test_obj_with_kwargs(self, obj_with_args, optimizer):
         """Test if kwargs are passed properly in objfunc"""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The goal of this PR is to support parallel particle evaluation in PySwarms.

~~### **This is a draft PR to collect feedback on implementation specific decision regarding this feature.**~~

~~At the moment, I only updated the optimize() implementation to use the `compute_objective_function` abstraction, but the same changes can be applied easily to the remaining optimizers.~~

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#258 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The main motivation for this PR is to improve the performance of PySwarms optimizers by parallelizing the evaluation of each particle during optimization.

This is especially relevant when: 
1. The objective function is expensive to compute.
2. The swarm has a high number of particles (thousands, millions, ...)

My proposal at the moment consists in abstracting the existing direct calls on the `objective_func` to a new method `compute_objective_function` that controls whether the evaluation should be done using parallelization or not.

Keep in mind that, since Python has a GIL we can't parallelize using threads and are forced to use `multiprocessing` to parallelize the computation across multiple processes.

Moving on the actual changes, there are some highlights that I'd like to explain:
1. Constructing a `multiprocessing.Pool` before starting the optimization iterations
   - Starting up new processes in every iteration for parallelization is expensive
   - We can just reuse the processes controlled by the Pool in every iteration
2. Passing `n_processes` in optimize method vs optimizer constructor
   - We may want to run the same optimizer configuration with varying degrees of parallelization.
   - This also further supports the idea of creating the Pool in the `optimize` method instead of during construction of the optimizer instance.
3. `partial(objective_func, **kwargs)` magic:
   - This is needed to support objective functions with arguments.

### **There is one small drawback at the moment** ⚠️ 
The objective functions built using the `cost` decorator are not supported in parallel execution scenarios. 

This happens because the `cost_dec` function is local to the decorator module and the module that starts up the Pool doesn't know about it, which makes the pickling process fail.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
At the moment, only a personal project that uses binary PSO and an expensive objective function.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

