### PR TITLE
Fix basic optimization example unknown arguments issues

### DIFF
--- a/docs/examples/basic_optimization.rst
+++ b/docs/examples/basic_optimization.rst
@@ -71,7 +71,7 @@ several variables at once.
     optimizer = ps.single.GlobalBestPSO(n_particles=10, dimensions=2, options=options)
     
     # Perform optimization
-    cost, pos = optimizer.optimize(fx.sphere, print_step=100, iters=1000, verbose=3)
+    cost, pos = optimizer.optimize(fx.sphere, iters=1000)
 
 
 .. parsed-literal::

--- a/docs/examples/inverse_kinematics.rst
+++ b/docs/examples/inverse_kinematics.rst
@@ -241,7 +241,7 @@ Braced with these preparations we can finally start using the algorithm:
                                         bounds=constraints)
 
     # Perform optimization
-    cost, joint_vars = optimizer.optimize(opt_func, print_step=100, iters=1000, verbose=3)
+    cost, joint_vars = optimizer.optimize(opt_func, iters=1000)
 
 
 .. parsed-literal::

--- a/examples/basic_optimization.ipynb
+++ b/examples/basic_optimization.ipynb
@@ -121,14 +121,7 @@
     "optimizer = ps.single.GlobalBestPSO(n_particles=10, dimensions=2, options=options)\n",
     "\n",
     "# Perform optimization\n",
-    "cost, pos = optimizer.optimize(fx.sphere, print_step=100, iters=1000, verbose=3)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can see that the optimizer was able to find a good minima as shown above. You can control the verbosity of the output using the `verbose` argument, and the number of steps to be printed out using the `print_step` argument."
+    "cost, pos = optimizer.optimize(fx.sphere, iters=1000)"
    ]
   },
   {

--- a/examples/inverse_kinematics.ipynb
+++ b/examples/inverse_kinematics.ipynb
@@ -322,7 +322,7 @@
     "                                    bounds=constraints)\n",
     "\n",
     "# Perform optimization\n",
-    "cost, joint_vars = optimizer.optimize(opt_func, print_step=100, iters=1000, verbose=3)"
+    "cost, joint_vars = optimizer.optimize(opt_func, iters=1000)"
    ]
   },
   {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove `verbose` and `print_step` arguments when calling `GlobalBestPSO` optimizer in multiple examples and docs. 

## Related Issue

Fixing outdated examples and documents issues reported in [issue 264](https://github.com/ljvmiranda921/pyswarms/issues/264) and in [issue 317](https://github.com/ljvmiranda921/pyswarms/issues/317).


## Motivation and Context
Thank you for providing great open source project.

Was trying to run inverse kinematics example and basic optimization example jupyter notebook. Original examples complain `unexpected keyword argument` errors for `verbose` and `print_step`. 

I haven't gone through the solver source code, hopefully this is the right fix that is inline with author's intention. 


## How Has This Been Tested?
Ran basic_optimization jupyter notebook locally. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

