### PR TITLE
Relax dependencies when installing via setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include HISTORY.rst
 include LICENSE
 include README.md
 include requirements.txt
+include requirements.in
 include requirements-dev.txt
 
 recursive-include tests *

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import find_packages, setup
 with open("README.md", encoding="utf8") as readme_file:
     readme = readme_file.read()
 
-with open("requirements.txt") as f:
+with open("requirements.in") as f:
     requirements = f.read().splitlines()
 
 with open("requirements-dev.txt") as f:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, flake8
+envlist = py35, py36, py37, flake8
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
Instead of using requirements.txt for installing via `pip` or `python setup.py install`, we are now just using a more relaxed `requirements.in`

## Description

There were some issues regarding the use of `requirements.txt` that causes some conflict with other installed packages when pyswarms is installed system-wide. By unpinning some dependencies in our library, we can remove such.

For pyswarms, there's really no hard requirement to depend upon numpy, scipy, etc.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#323 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

