### PR TITLE
Added pyyaml in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ python-dateutil==2.7.5
 scipy==1.2.0
 six==1.12.0
 tqdm==4.24.0
+pyyaml==5.1.1


### PR DESCRIPTION
Don't know why it was removed after #300, but it's still missing from PyPI and the master branch. Please feel free to comment on the version (or anything).

#300 provides the background.

Thanks.