### PR TITLE
Minor fixes

### DIFF
--- a/pyswarms/backend/handlers.py
+++ b/pyswarms/backend/handlers.py
@@ -140,7 +140,7 @@ class BoundaryHandler(HandlerMixin):
             return new_position
 
     def nearest(self, position, bounds, **kwargs):
-        """Set position to nearest bound
+        r"""Set position to nearest bound
 
         This method resets particles that exceed the bounds to the nearest
         available boundary. For every axis on which the coordiantes of the particle
@@ -165,7 +165,7 @@ class BoundaryHandler(HandlerMixin):
         return new_pos
 
     def reflective(self, position, bounds, **kwargs):
-        """Reflect the particle at the boundary
+        r"""Reflect the particle at the boundary
 
         This method reflects the particles that exceed the bounds at the
         respective boundary. This means that the amount that the component
@@ -211,7 +211,7 @@ class BoundaryHandler(HandlerMixin):
         return new_pos
 
     def shrink(self, position, bounds, **kwargs):
-        """Set the particle to the boundary
+        r"""Set the particle to the boundary
 
         This method resets particles that exceed the bounds to the intersection
         of its previous velocity and the boundary. This can be imagined as shrinking
@@ -492,7 +492,7 @@ class VelocityHandler(HandlerMixin):
             return new_vel
 
     def invert(self, velocity, clamp=None, **kwargs):
-        """Invert the velocity if the particle is out of bounds
+        r"""Invert the velocity if the particle is out of bounds
 
         The velocity is inverted and shrinked. The shrinking is determined by the
         kwarg :code:`z`. The default shrinking factor is :code:`0.5`. For all

--- a/pyswarms/utils/reporter/reporter.py
+++ b/pyswarms/utils/reporter/reporter.py
@@ -127,7 +127,7 @@ class Reporter(object):
         You can check logging levels on this `link`_. In essence, DEBUG is 10,
         INFO is 20, WARNING is 30, ERROR is 40, and CRITICAL is 50.
 
-        .. link: https://docs.python.org/3/library/logging.html#logging-levels
+        .. _link: https://docs.python.org/3/library/logging.html#logging-levels
 
         Parameters
         ----------

--- a/pyswarms/utils/search/base_search.py
+++ b/pyswarms/utils/search/base_search.py
@@ -47,6 +47,7 @@ class SearchBase(object):
         options : dict with keys :code:`{'c1', 'c2', 'w', 'k', 'p'}`
             a dictionary containing the parameters for the specific
             optimization technique
+
                 * c1 : float
                     cognitive parameter
                 * c2 : float
@@ -60,6 +61,7 @@ class SearchBase(object):
                     the Minkowski p-norm to use. 1 is the
                     sum-of-absolute values (or L1 distance) while 2 is
                     the Euclidean (or L2) distance.
+
         objective_func: function
             objective function to be evaluated
         iters: int


### PR DESCRIPTION
This resolves a rendering issue with [handlers](https://pyswarms.readthedocs.io/en/latest/api/pyswarms.handlers.html) (see, for example, [here](https://pyswarms.readthedocs.io/en/latest/api/pyswarms.handlers.html#pyswarms.backend.handlers.BoundaryHandler.nearest)), as well as minor docstring issues producing warnings during documentation rebuild.