### PR TITLE
Fix for Issue #397

### DIFF
--- a/pyswarms/base/base_discrete.py
+++ b/pyswarms/base/base_discrete.py
@@ -49,7 +49,7 @@ class DiscreteSwarmOptimizer(abc.ABC):
         velocity_clamp=None,
         init_pos=None,
         ftol=-np.inf,
-        ftol_iter=1,
+        ftol_iter=0,
     ):
         """Initialize the swarm.
 
@@ -83,11 +83,12 @@ class DiscreteSwarmOptimizer(abc.ABC):
             sets the limits for velocity clamping.
         ftol : float, optional
             relative error in objective_func(best_pos) acceptable for
-            convergence. Default is :code:`-np.inf`.
+            convergence. Default is :code:`-np.inf` (disabled)
         ftol_iter : int
             number of iterations over which the relative error in
             objective_func(best_pos) is acceptable for convergence.
-            Default is :code:`1`
+            Set to greater than 5 to avoid stopping too early and getting an immature solution.
+            Default is :code:`0` (disabled)
         options: dict
             a dictionary containing the parameters for a specific
             optimization technique

--- a/pyswarms/base/base_single.py
+++ b/pyswarms/base/base_single.py
@@ -50,7 +50,7 @@ class SwarmOptimizer(abc.ABC):
         velocity_clamp=None,
         center=1.0,
         ftol=-np.inf,
-        ftol_iter=1,
+        ftol_iter=0,
         init_pos=None,
     ):
         """Initialize the swarm
@@ -84,11 +84,12 @@ class SwarmOptimizer(abc.ABC):
             an array of size :code:`dimensions`
         ftol : float, optional
             relative error in objective_func(best_pos) acceptable for
-            convergence. Default is :code:`-np.inf`.
+            convergence. Default is :code:`-np.inf` (disabled).
         ftol_iter : int
             number of iterations over which the relative error in
             objective_func(best_pos) is acceptable for convergence.
-            Default is :code:`1`
+            Set to greater than 5 to avoid stopping too early and getting an immature solution.
+            Default is :code:`0` (disabled)
         """
         # Initialize primary swarm attributes
         self.n_particles = n_particles

--- a/pyswarms/discrete/binary.py
+++ b/pyswarms/discrete/binary.py
@@ -188,8 +188,7 @@ class BinaryPSO(DiscreteSwarmOptimizer):
         self.swarm.pbest_cost = np.full(self.swarm_size[0], np.inf)
         ftol_history = [None] * self.ftol_iter
         # Default reason for optimization completion
-        stop_reason = "«iters={}» reached".format(iters)
-        
+        stop_reason = "«iters={}» reached".format(iters) 
         for i in range(iters) if verbose else self.rep.pbar(iters, self.name):
             # Compute cost for current position and personal best
             self.swarm.current_cost = compute_objective_function(

--- a/pyswarms/discrete/binary.py
+++ b/pyswarms/discrete/binary.py
@@ -142,7 +142,7 @@ class BinaryPSO(DiscreteSwarmOptimizer):
         self.vh = VelocityHandler(strategy=vh_strategy)
         self.name = __name__
 
-    def optimize(self, objective_func, iters, n_processes=None, verbose=False, **kwargs):
+    def optimize(self, objective_func, iters, n_processes=None, verbose=True, **kwargs):
         """Optimize the swarm for a number of iterations
 
         Performs the optimization to evaluate the objective
@@ -158,7 +158,7 @@ class BinaryPSO(DiscreteSwarmOptimizer):
             number of processes to use for parallel particle evaluation
             Defaut is None with no parallelization.
         verbose : bool
-            enable or disable the logs and progress bar (default: False = enable logs)
+            enable or disable the logs and progress bar (default: True = enable logs)
         kwargs : dict
             arguments for objective function
 
@@ -170,9 +170,9 @@ class BinaryPSO(DiscreteSwarmOptimizer):
         """
         # Apply verbosity
         if verbose:
-            logginglevel = logging.NOTSET
-        else:
             logginglevel = logging.INFO
+        else:
+            logginglevel = logging.NOTSET
             
         self.rep.log("Obj. func. args: {}".format(kwargs), lvl=logging.DEBUG)
         self.rep.log(
@@ -202,7 +202,7 @@ class BinaryPSO(DiscreteSwarmOptimizer):
             self.swarm.best_pos, self.swarm.best_cost = self.top.compute_gbest(
                 self.swarm, p=self.p, k=self.k
             )
-            if not verbose:
+            if verbose:
                 # Print to console
                 self.rep.hook(best_cost=self.swarm.best_cost)
             # Save to history
@@ -241,7 +241,7 @@ class BinaryPSO(DiscreteSwarmOptimizer):
         final_best_cost = self.swarm.best_cost.copy()
         final_best_pos = self.swarm.pbest_pos[self.swarm.pbest_cost.argmin()].copy()
         # close the progress bar
-        if not verbose: self.rep.t.close()
+        if verbose: self.rep.t.close()
         # Write report in log and return final cost and position
         self.rep.log(
             "Optimization finished | {} | Last iteration: {}) |\nbest cost: {}, best pos: {}".format(

--- a/pyswarms/discrete/binary.py
+++ b/pyswarms/discrete/binary.py
@@ -189,7 +189,7 @@ class BinaryPSO(DiscreteSwarmOptimizer):
         ftol_history = [None] * self.ftol_iter
         # Default reason for optimization completion
         stop_reason = "«iters={}» reached".format(iters) 
-        for i in range(iters) if verbose else self.rep.pbar(iters, self.name):
+        for i in self.rep.pbar(iters, self.name) if verbose else range(iters):
             # Compute cost for current position and personal best
             self.swarm.current_cost = compute_objective_function(
                 self.swarm, objective_func, pool, **kwargs

--- a/pyswarms/single/general_optimizer.py
+++ b/pyswarms/single/general_optimizer.py
@@ -188,7 +188,7 @@ class GeneralOptimizerPSO(SwarmOptimizer):
         self.vh = VelocityHandler(strategy=vh_strategy)
         self.name = __name__
 
-    def optimize(self, objective_func, iters, n_processes=None, verbose=False, **kwargs):
+    def optimize(self, objective_func, iters, n_processes=None, verbose=True, **kwargs):
         """Optimize the swarm for a number of iterations
 
         Performs the optimization to evaluate the objective
@@ -214,9 +214,9 @@ class GeneralOptimizerPSO(SwarmOptimizer):
         """
         # Apply verbosity
         if verbose:
-            logginglevel = logging.NOTSET
-        else:
             logginglevel = logging.INFO
+        else:
+            logginglevel = logging.NOTSET
             
         self.rep.log("Obj. func. args: {}".format(kwargs), lvl=logging.DEBUG)
         self.rep.log(
@@ -247,7 +247,7 @@ class GeneralOptimizerPSO(SwarmOptimizer):
                 self.swarm, **self.options
             )
             # Print to console
-            if not verbose:
+            if verbose:
                 self.rep.hook(best_cost=self.swarm.best_cost)
             hist = self.ToHistory(
                 best_cost=self.swarm.best_cost,
@@ -288,7 +288,7 @@ class GeneralOptimizerPSO(SwarmOptimizer):
             self.swarm.pbest_cost.argmin()
         ].copy()
         # close the progress bar
-        if not verbose: self.rep.t.close()
+        if verbose: self.rep.t.close()
         # Write report in log and return final cost and position
         self.rep.log(
             "Optimization finished | {} | Last iteration: {}) |\nbest cost: {}, best pos: {}".format(

--- a/pyswarms/single/general_optimizer.py
+++ b/pyswarms/single/general_optimizer.py
@@ -83,7 +83,7 @@ class GeneralOptimizerPSO(SwarmOptimizer):
         vh_strategy="unmodified",
         center=1.00,
         ftol=-np.inf,
-        ftol_iter=1,
+        ftol_iter=0,
         init_pos=None,
     ):
         """Initialize the swarm
@@ -153,11 +153,12 @@ class GeneralOptimizerPSO(SwarmOptimizer):
             an array of size :code:`dimensions`
         ftol : float
             relative error in objective_func(best_pos) acceptable for
-            convergence. Default is :code:`-np.inf`
+            convergence. Default is :code:`-np.inf` (disabled)
         ftol_iter : int
             number of iterations over which the relative error in
             objective_func(best_pos) is acceptable for convergence.
-            Default is :code:`1`
+            Set to greater than 5 to avoid stopping too early and getting an immature solution.
+            Default is :code:`0` (disabled)
         init_pos : numpy.ndarray, optional
             option to explicitly set the particles' initial positions. Set to
             :code:`None` if you wish to generate the particles randomly.
@@ -232,6 +233,9 @@ class GeneralOptimizerPSO(SwarmOptimizer):
 
         self.swarm.pbest_cost = np.full(self.swarm_size[0], np.inf)
         ftol_history = [None] * self.ftol_iter
+        # Default reason for optimization completion
+        stop_reason = "«iters={}» reached".format(iters)
+        
         for i in range(iters) if verbose else self.rep.pbar(iters, self.name):
             # Compute cost for current position and personal best
             # fmt: off
@@ -256,13 +260,22 @@ class GeneralOptimizerPSO(SwarmOptimizer):
             self._populate_history(hist)
             # Verify stop criteria based on the relative acceptable cost ftol
             relative_measure = self.ftol * (1 + np.abs(best_cost_yet_found))
-            delta = np.abs(self.swarm.best_cost - best_cost_yet_found) < relative_measure
-            if i < self.ftol_iter:
-                ftol_history[i] = delta
-            else:
-                ftol_history = ftol_history[1:] + [delta]
-                if all(ftol_history):
-                    break
+            costs_diff = np.abs(self.swarm.best_cost - best_cost_yet_found)
+            isBelow_ftol = costs_diff < relative_measure
+            
+            # Check if ftol reached, exclude no change in the best_cost
+            if isBelow_ftol and costs_diff != 0:
+                stop_reason = "«ftol={}» reached".format(self.ftol)
+                break
+            # Check if ftol_iter reached, include no change in the best_cost
+            if self.ftol_iter:
+                if i < self.ftol_iter:
+                    ftol_history[i] = isBelow_ftol
+                else:
+                    ftol_history = ftol_history[1:] + [isBelow_ftol]
+                    if all(ftol_history):
+                        stop_reason = "«ftol_iter={}» reached".format(self.ftol_iter)
+                        break
             # Perform velocity and position updates
             self.swarm.velocity = self.top.compute_velocity(
                 self.swarm, self.velocity_clamp, self.vh, self.bounds
@@ -275,10 +288,12 @@ class GeneralOptimizerPSO(SwarmOptimizer):
         final_best_pos = self.swarm.pbest_pos[
             self.swarm.pbest_cost.argmin()
         ].copy()
+        # close the progress bar
+        if not verbose: self.rep.t.close()
         # Write report in log and return final cost and position
         self.rep.log(
-            "Optimization finished | best cost: {}, best pos: {}".format(
-                final_best_cost, final_best_pos
+            "Optimization finished | {} | Last iteration: {}) |\nbest cost: {}, best pos: {}".format(
+                stop_reason, i + 1, final_best_cost, final_best_pos
             ),
             lvl=logginglevel,
         )

--- a/pyswarms/single/general_optimizer.py
+++ b/pyswarms/single/general_optimizer.py
@@ -283,5 +283,6 @@ class GeneralOptimizerPSO(SwarmOptimizer):
             lvl=logginglevel,
         )
         # Close Pool of Processes
-        pool.close()
+        if n_processes is not None:
+            pool.close()
         return (final_best_cost, final_best_pos)

--- a/pyswarms/single/general_optimizer.py
+++ b/pyswarms/single/general_optimizer.py
@@ -235,7 +235,7 @@ class GeneralOptimizerPSO(SwarmOptimizer):
         ftol_history = [None] * self.ftol_iter
         # Default reason for optimization completion
         stop_reason = "«iters={}» reached".format(iters)
-        for i in range(iters) if verbose else self.rep.pbar(iters, self.name):
+        for i in self.rep.pbar(iters, self.name) if verbose else range(iters):
             # Compute cost for current position and personal best
             # fmt: off
             self.swarm.current_cost = compute_objective_function(self.swarm, objective_func, pool=pool, **kwargs)

--- a/pyswarms/single/general_optimizer.py
+++ b/pyswarms/single/general_optimizer.py
@@ -203,7 +203,7 @@ class GeneralOptimizerPSO(SwarmOptimizer):
         n_processes : int
             number of processes to use for parallel particle evaluation (default: None = no parallelization)
         verbose : bool
-            enable or disable the logs and progress bar (default: False = enable logs)
+            enable or disable the logs and progress bar (default: True = enable logs)
         kwargs : dict
             arguments for the objective function
 

--- a/pyswarms/single/general_optimizer.py
+++ b/pyswarms/single/general_optimizer.py
@@ -235,7 +235,6 @@ class GeneralOptimizerPSO(SwarmOptimizer):
         ftol_history = [None] * self.ftol_iter
         # Default reason for optimization completion
         stop_reason = "«iters={}» reached".format(iters)
-        
         for i in range(iters) if verbose else self.rep.pbar(iters, self.name):
             # Compute cost for current position and personal best
             # fmt: off

--- a/pyswarms/single/global_best.py
+++ b/pyswarms/single/global_best.py
@@ -240,5 +240,6 @@ class GlobalBestPSO(SwarmOptimizer):
             lvl=logginglevel,
         )
         # Close Pool of Processes
-        pool.close()
+        if n_processes is not None:
+            pool.close()
         return (final_best_cost, final_best_pos)

--- a/pyswarms/single/global_best.py
+++ b/pyswarms/single/global_best.py
@@ -239,4 +239,6 @@ class GlobalBestPSO(SwarmOptimizer):
             ),
             lvl=logginglevel,
         )
+        # Close Pool of Processes
+        pool.close()
         return (final_best_cost, final_best_pos)

--- a/pyswarms/single/global_best.py
+++ b/pyswarms/single/global_best.py
@@ -222,11 +222,11 @@ class GlobalBestPSO(SwarmOptimizer):
             costs_diff = np.abs(self.swarm.best_cost - best_cost_yet_found)
             isBelow_ftol =  costs_diff < relative_measure
             
-            # Check if ftol reached, exclude no change in best_cost
+            # Check if ftol reached, exclude no change in the best_cost
             if isBelow_ftol and costs_diff != 0:
                 stop_reason = "«ftol={}» reached".format(self.ftol)
                 break
-            # Check if ftol_iter reached, include no change in best_cost
+            # Check if ftol_iter reached, include no change in the best_cost
             if self.ftol_iter:
                 if i < self.ftol_iter:
                     ftol_history[i] = isBelow_ftol

--- a/pyswarms/single/global_best.py
+++ b/pyswarms/single/global_best.py
@@ -196,7 +196,6 @@ class GlobalBestPSO(SwarmOptimizer):
         ftol_history = [None] * self.ftol_iter
         # Default reason for optimization completion
         stop_reason = "«iters={}» reached".format(iters)
-        
         for i in range(iters) if verbose else self.rep.pbar(iters, self.name):
             # Compute cost for current position and personal best
             # fmt: off

--- a/pyswarms/single/global_best.py
+++ b/pyswarms/single/global_best.py
@@ -149,7 +149,7 @@ class GlobalBestPSO(SwarmOptimizer):
         self.vh = VelocityHandler(strategy=vh_strategy)
         self.name = __name__
 
-    def optimize(self, objective_func, iters, n_processes=None, verbose=False, **kwargs):
+    def optimize(self, objective_func, iters, n_processes=None, verbose=True, **kwargs):
         """Optimize the swarm for a number of iterations
 
         Performs the optimization to evaluate the objective
@@ -164,7 +164,7 @@ class GlobalBestPSO(SwarmOptimizer):
         n_processes : int
             number of processes to use for parallel particle evaluation (default: None = no parallelization)
         verbose : bool
-            enable or disable the logs and progress bar (default: False = enable logs)
+            enable or disable the logs and progress bar (default: True = enable logs)
         kwargs : dict
             arguments for the objective function
 
@@ -176,9 +176,9 @@ class GlobalBestPSO(SwarmOptimizer):
         
         # Apply verbosity
         if verbose:
-            logginglevel = logging.NOTSET
-        else:
             logginglevel = logging.INFO
+        else:
+            logginglevel = logging.NOTSET
 
         self.rep.log("Obj. func. args: {}".format(kwargs), lvl=logging.DEBUG)
         self.rep.log(
@@ -205,7 +205,7 @@ class GlobalBestPSO(SwarmOptimizer):
             best_cost_yet_found = self.swarm.best_cost
             self.swarm.best_pos, self.swarm.best_cost = self.top.compute_gbest(self.swarm)
             # fmt: on
-            if not verbose:
+            if verbose:
                 self.rep.hook(best_cost=self.swarm.best_cost)
             # Save to history
             hist = self.ToHistory(
@@ -245,7 +245,7 @@ class GlobalBestPSO(SwarmOptimizer):
         final_best_cost = self.swarm.best_cost.copy()
         final_best_pos = self.swarm.pbest_pos[self.swarm.pbest_cost.argmin()].copy()
         # close the progress bar
-        if not verbose: self.rep.t.close()
+        if verbose: self.rep.t.close()
         # Write report in log and return final cost and position
         self.rep.log(
             "Optimization finished | {} | Last iteration: {}) |\nbest cost: {}, best pos: {}".format(

--- a/pyswarms/single/global_best.py
+++ b/pyswarms/single/global_best.py
@@ -196,7 +196,7 @@ class GlobalBestPSO(SwarmOptimizer):
         ftol_history = [None] * self.ftol_iter
         # Default reason for optimization completion
         stop_reason = "«iters={}» reached".format(iters)
-        for i in range(iters) if verbose else self.rep.pbar(iters, self.name):
+        for i in self.rep.pbar(iters, self.name) if verbose else range(iters):
             # Compute cost for current position and personal best
             # fmt: off
             self.swarm.current_cost = compute_objective_function(self.swarm, objective_func, pool=pool, **kwargs)

--- a/pyswarms/single/local_best.py
+++ b/pyswarms/single/local_best.py
@@ -173,7 +173,7 @@ class LocalBestPSO(SwarmOptimizer):
         self.vh = VelocityHandler(strategy=vh_strategy)
         self.name = __name__
 
-    def optimize(self, objective_func, iters, n_processes=None, verbose=False, **kwargs):
+    def optimize(self, objective_func, iters, n_processes=None, verbose=True, **kwargs):
         """Optimize the swarm for a number of iterations
 
         Performs the optimization to evaluate the objective
@@ -188,7 +188,7 @@ class LocalBestPSO(SwarmOptimizer):
         n_processes : int
             number of processes to use for parallel particle evaluation (default: None = no parallelization)
         verbose : bool
-            enable or disable the logs and progress bar (default: False = enable logs)
+            enable or disable the logs and progress bar (default: True = enable logs)
         kwargs : dict
             arguments for the objective function
 
@@ -200,9 +200,9 @@ class LocalBestPSO(SwarmOptimizer):
         """
         # Apply verbosity
         if verbose:
-            logginglevel = logging.NOTSET
-        else:
             logginglevel = logging.INFO
+        else:
+            logginglevel = logging.NOTSET
             
         self.rep.log("Obj. func. args: {}".format(kwargs), lvl=logging.DEBUG)
         self.rep.log(
@@ -233,7 +233,7 @@ class LocalBestPSO(SwarmOptimizer):
             self.swarm.best_pos, self.swarm.best_cost = self.top.compute_gbest(
                 self.swarm, p=self.p, k=self.k
             )
-            if not verbose:
+            if verbose:
                 self.rep.hook(best_cost=np.min(self.swarm.best_cost))
             # Save to history
             hist = self.ToHistory(
@@ -273,7 +273,7 @@ class LocalBestPSO(SwarmOptimizer):
         final_best_cost = self.swarm.best_cost.copy()
         final_best_pos = self.swarm.pbest_pos[self.swarm.pbest_cost.argmin()].copy()
         # close the progress bar
-        if not verbose: self.rep.t.close()
+        if verbose: self.rep.t.close()
         # Write report in log and return final cost and position
         self.rep.log(
             "Optimization finished | {} | Last iteration: {}) |\nbest cost: {}, best pos: {}".format(

--- a/pyswarms/single/local_best.py
+++ b/pyswarms/single/local_best.py
@@ -220,7 +220,6 @@ class LocalBestPSO(SwarmOptimizer):
         ftol_history = [None] * self.ftol_iter
         # Default reason for optimization completion
         stop_reason = "«iters={}» reached".format(iters)
-        
         for i in range(iters) if verbose else self.rep.pbar(iters, self.name):
             # Compute cost for current position and personal best
             self.swarm.current_cost = compute_objective_function(

--- a/pyswarms/single/local_best.py
+++ b/pyswarms/single/local_best.py
@@ -90,7 +90,7 @@ class LocalBestPSO(SwarmOptimizer):
         vh_strategy="unmodified",
         center=1.00,
         ftol=-np.inf,
-        ftol_iter=1,
+        ftol_iter=0,
         init_pos=None,
         static=False,
     ):
@@ -118,11 +118,12 @@ class LocalBestPSO(SwarmOptimizer):
             an array of size :code:`dimensions`
         ftol : float
             relative error in objective_func(best_pos) acceptable for
-            convergence. Default is :code:`-np.inf`
+            convergence. Default is :code:`-np.inf` (disabled)
         ftol_iter : int
             number of iterations over which the relative error in
             objective_func(best_pos) is acceptable for convergence.
-            Default is :code:`1`
+            Set to greater than 5 to avoid stopping too early and getting an immature solution.
+            Default is :code:`0` (disabled)
         options : dict with keys :code:`{'c1', 'c2', 'w', 'k', 'p'}`
             a dictionary containing the parameters for the specific
             optimization technique
@@ -217,6 +218,9 @@ class LocalBestPSO(SwarmOptimizer):
 
         self.swarm.pbest_cost = np.full(self.swarm_size[0], np.inf)
         ftol_history = [None] * self.ftol_iter
+        # Default reason for optimization completion
+        stop_reason = "«iters={}» reached".format(iters)
+        
         for i in range(iters) if verbose else self.rep.pbar(iters, self.name):
             # Compute cost for current position and personal best
             self.swarm.current_cost = compute_objective_function(
@@ -243,13 +247,22 @@ class LocalBestPSO(SwarmOptimizer):
             self._populate_history(hist)
             # Verify stop criteria based on the relative acceptable cost ftol
             relative_measure = self.ftol * (1 + np.abs(best_cost_yet_found))
-            delta = np.abs(self.swarm.best_cost - best_cost_yet_found) < relative_measure
-            if i < self.ftol_iter:
-                ftol_history[i] = delta
-            else:
-                ftol_history = ftol_history[1:] + [delta]
-                if all(ftol_history):
-                    break
+            costs_diff = np.abs(self.swarm.best_cost - best_cost_yet_found)
+            isBelow_ftol = costs_diff < relative_measure
+            
+            # Check if ftol reached, exclude no change in the best_cost
+            if isBelow_ftol and costs_diff != 0:
+                stop_reason = "«ftol={}» reached".format(self.ftol)
+                break
+            # Check if ftol_iter reached, include no change in the best_cost
+            if self.ftol_iter:
+                if i < self.ftol_iter:
+                    ftol_history[i] = isBelow_ftol
+                else:
+                    ftol_history = ftol_history[1:] + [isBelow_ftol]
+                    if all(ftol_history):
+                        stop_reason = "«ftol_iter={}» reached".format(self.ftol_iter)
+                        break
             # Perform position velocity update
             self.swarm.velocity = self.top.compute_velocity(
                 self.swarm, self.velocity_clamp, self.vh, self.bounds
@@ -260,10 +273,12 @@ class LocalBestPSO(SwarmOptimizer):
         # Obtain the final best_cost and the final best_position
         final_best_cost = self.swarm.best_cost.copy()
         final_best_pos = self.swarm.pbest_pos[self.swarm.pbest_cost.argmin()].copy()
+        # close the progress bar
+        if not verbose: self.rep.t.close()
         # Write report in log and return final cost and position
         self.rep.log(
-            "Optimization finished | best cost: {}, best pos: {}".format(
-                final_best_cost, final_best_pos
+            "Optimization finished | {} | Last iteration: {}) |\nbest cost: {}, best pos: {}".format(
+                stop_reason, i + 1, final_best_cost, final_best_pos
             ),
             lvl=logginglevel,
         )

--- a/pyswarms/single/local_best.py
+++ b/pyswarms/single/local_best.py
@@ -268,5 +268,6 @@ class LocalBestPSO(SwarmOptimizer):
             lvl=logginglevel,
         )
         # Close Pool of Processes
-        pool.close()
+        if n_processes is not None:
+            pool.close()
         return (final_best_cost, final_best_pos)

--- a/pyswarms/single/local_best.py
+++ b/pyswarms/single/local_best.py
@@ -172,7 +172,7 @@ class LocalBestPSO(SwarmOptimizer):
         self.vh = VelocityHandler(strategy=vh_strategy)
         self.name = __name__
 
-    def optimize(self, objective_func, iters, n_processes=None, **kwargs):
+    def optimize(self, objective_func, iters, n_processes=None, verbose=False, **kwargs):
         """Optimize the swarm for a number of iterations
 
         Performs the optimization to evaluate the objective
@@ -186,6 +186,8 @@ class LocalBestPSO(SwarmOptimizer):
             number of iterations
         n_processes : int
             number of processes to use for parallel particle evaluation (default: None = no parallelization)
+        verbose : bool
+            enable or disable the logs and progress bar (default: False = enable logs)
         kwargs : dict
             arguments for the objective function
 
@@ -195,10 +197,16 @@ class LocalBestPSO(SwarmOptimizer):
             the local best cost and the local best position among the
             swarm.
         """
+        # Apply verbosity
+        if verbose:
+            logginglevel = logging.NOTSET
+        else:
+            logginglevel = logging.INFO
+            
         self.rep.log("Obj. func. args: {}".format(kwargs), lvl=logging.DEBUG)
         self.rep.log(
             "Optimize for {} iters with {}".format(iters, self.options),
-            lvl=logging.INFO,
+            lvl=logginglevel,
         )
         # Populate memory of the handlers
         self.bh.memory = self.swarm.position
@@ -209,7 +217,7 @@ class LocalBestPSO(SwarmOptimizer):
 
         self.swarm.pbest_cost = np.full(self.swarm_size[0], np.inf)
         ftol_history = [None] * self.ftol_iter
-        for i in self.rep.pbar(iters, self.name):
+        for i in range(iters) if verbose else self.rep.pbar(iters, self.name):
             # Compute cost for current position and personal best
             self.swarm.current_cost = compute_objective_function(
                 self.swarm, objective_func, pool=pool, **kwargs
@@ -222,7 +230,8 @@ class LocalBestPSO(SwarmOptimizer):
             self.swarm.best_pos, self.swarm.best_cost = self.top.compute_gbest(
                 self.swarm, p=self.p, k=self.k
             )
-            self.rep.hook(best_cost=np.min(self.swarm.best_cost))
+            if not verbose:
+                self.rep.hook(best_cost=self.swarm.best_cost)
             # Save to history
             hist = self.ToHistory(
                 best_cost=self.swarm.best_cost,
@@ -256,6 +265,6 @@ class LocalBestPSO(SwarmOptimizer):
             "Optimization finished | best cost: {}, best pos: {}".format(
                 final_best_cost, final_best_pos
             ),
-            lvl=logging.INFO,
+            lvl=logginglevel,
         )
         return (final_best_cost, final_best_pos)

--- a/pyswarms/single/local_best.py
+++ b/pyswarms/single/local_best.py
@@ -220,7 +220,7 @@ class LocalBestPSO(SwarmOptimizer):
         ftol_history = [None] * self.ftol_iter
         # Default reason for optimization completion
         stop_reason = "«iters={}» reached".format(iters)
-        for i in range(iters) if verbose else self.rep.pbar(iters, self.name):
+        for i in self.rep.pbar(iters, self.name) if verbose else range(iters):
             # Compute cost for current position and personal best
             self.swarm.current_cost = compute_objective_function(
                 self.swarm, objective_func, pool=pool, **kwargs

--- a/pyswarms/single/local_best.py
+++ b/pyswarms/single/local_best.py
@@ -231,7 +231,7 @@ class LocalBestPSO(SwarmOptimizer):
                 self.swarm, p=self.p, k=self.k
             )
             if not verbose:
-                self.rep.hook(best_cost=self.swarm.best_cost)
+                self.rep.hook(best_cost=np.min(self.swarm.best_cost))
             # Save to history
             hist = self.ToHistory(
                 best_cost=self.swarm.best_cost,
@@ -267,4 +267,6 @@ class LocalBestPSO(SwarmOptimizer):
             ),
             lvl=logginglevel,
         )
+        # Close Pool of Processes
+        pool.close()
         return (final_best_cost, final_best_pos)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Early unwanted stopping if `ftol` is used, no matter what threshold is set, because of no change in `best_cost` in two consecutive iterations.


## Related Issue
* [#397](https://github.com/ljvmiranda921/pyswarms/issues/397)

* The logger was also improved to show the termination condition, and a bug in showing the progress bar was fixed too.

* Functions docstrings were also updated.


## Motivation and Context
It avoids having an unwanted stop.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All GlobalBestPSO, LocalBestPSO, and GeneralOptimizerPSO were tested for Sphere(), with following criteria:
- `n_particles=50, dimensions=2, iters=300`
- without `ftol`  («iters=300» reached)
- `ftol=1e-60`   («iters=300» reached)
- `ftol=1e-3`  («ftol=0.001» reached)
- `ftol=1e-10, ftol_iter=5`  («ftol_iter=5» reached)
- `ftol=1e-60, ftol_iter=50`  («iters=300» reached)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

