### PR TITLE
Fix doc typos in binary discrete optimizer module (pyswarms.discrete.binary)

### DIFF
--- a/pyswarms/discrete/binary.py
+++ b/pyswarms/discrete/binary.py
@@ -87,7 +87,7 @@ class BinaryPSO(DiscreteSwarmOptimizer):
             number of particles in the swarm.
         dimensions : int
             number of dimensions in the space.
-        options : dict with keys :code:`{'c1', 'c2', 'k', 'p'}`
+        options : dict with keys :code:`{'c1', 'c2', 'w', 'k', 'p'}`
             a dictionary containing the parameters for the specific
             optimization technique
                 * c1 : float

--- a/pyswarms/discrete/binary.py
+++ b/pyswarms/discrete/binary.py
@@ -14,7 +14,7 @@ proceeding equation:
 
 .. math::
 
-   v_{ij}(t + 1) = m * v_{ij}(t) + c_{1}r_{1j}(t)[y_{ij}(t) − x_{ij}(t)] + c_{2}r_{2j}(t)[\hat{y}_{j}(t) − x_{ij}(t)]
+   v_{ij}(t + 1) = w * v_{ij}(t) + c_{1}r_{1j}(t)[y_{ij}(t) − x_{ij}(t)] + c_{2}r_{2j}(t)[\hat{y}_{j}(t) − x_{ij}(t)]
 
 For the velocity update rule, a particle compares its current position
 with respect to its neighbours. The nearest neighbours are being


### PR DESCRIPTION
## Description
Since `m` wasn't defined anywhere, I assumed the inertia `w` was actually meant here, similar to the formula for the real-valued algorithm. In addition to that, the `w` key was also missing in documentation for the options dict keyword argument in the initialization of `BinaryPSO`, fixed that as well.

## Related Issue
I guess #389 ?

## Motivation and Context
This change improves the clarity of the documentation.

## How Has This Been Tested?
Not applicable.

## Screenshots (if appropriate):
Not applicable.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

