### PR TITLE
Fix typo on train_neural_network.ipynb

### DIFF
--- a/docs/examples/usecases/train_neural_network.ipynb
+++ b/docs/examples/usecases/train_neural_network.ipynb
@@ -183,7 +183,7 @@
     "        The computed negative log-likelihood loss given the parameters\n",
     "    \"\"\"\n",
     "    \n",
-    "    logits = logits_funciton(params)\n",
+    "    logits = logits_function(params)\n",
     "    \n",
     "    # Compute for the softmax of the logits\n",
     "    exp_scores = np.exp(logits)\n",
@@ -282,7 +282,7 @@
     "        Position matrix found by the swarm. Will be rolled\n",
     "        into weights and biases.\n",
     "    \"\"\"\n",
-    "    logits = logits_funciton(pos)\n",
+    "    logits = logits_function(pos)\n",
     "    y_pred = np.argmax(logits, axis=1)\n",
     "    return y_pred"
    ]


### PR DESCRIPTION
## Description
There is a typo on train_neural_network.ipynb, this PR fix that typo.

## Related Issue
Solves Issue #428 

## Motivation and Context
In cell 5 is defined logits_function, but in cells 6 and 9 is written logits_funciton. This pull request fix the typo.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

