### PR TITLE
Improving ftol_iter

### DIFF
--- a/pyswarms/base/base_discrete.py
+++ b/pyswarms/base/base_discrete.py
@@ -49,7 +49,7 @@ class DiscreteSwarmOptimizer(abc.ABC):
         velocity_clamp=None,
         init_pos=None,
         ftol=-np.inf,
-        ftol_iter=1,
+        ftol_iter=50,
     ):
         """Initialize the swarm.
 
@@ -81,13 +81,16 @@ class DiscreteSwarmOptimizer(abc.ABC):
             a tuple of size 2 where the first entry is the minimum velocity
             and the second entry is the maximum velocity. It
             sets the limits for velocity clamping.
-        ftol : float, optional
-            relative error in objective_func(best_pos) acceptable for
-            convergence. Default is :code:`-np.inf`.
+        ftol : float
+            relative error in objective_func(best_pos) acceptable for convergence.
+            To deactivate it in order to process all iterations, use any negative value.
+            Deactivating ftol also disables ftol_iter.
+            Default is :code: `-np.inf` to disable ftol
         ftol_iter : int
-            number of iterations over which the relative error in
-            objective_func(best_pos) is acceptable for convergence.
-            Default is :code:`1`
+            number of consecutive iterations over which the relative change in
+            objective_func(best_pos) is stalled or less than ftol. It works
+            when ftol is greater than zero (e.g. 1e-6)
+            Default is :code:`50`
         options: dict
             a dictionary containing the parameters for a specific
             optimization technique
@@ -146,7 +149,7 @@ class DiscreteSwarmOptimizer(abc.ABC):
         self.velocity_history.append(hist.velocity)
 
     @abc.abstractmethod
-    def optimize(self, objective_func, iters, n_processes=None, **kwargs):
+    def optimize(self, objective_func, iters=1000, n_processes=None, **kwargs):
         """Optimize the swarm for a number of iterations
 
         Performs the optimization to evaluate the objective
@@ -158,7 +161,7 @@ class DiscreteSwarmOptimizer(abc.ABC):
         objective_func : callable
             objective function to be evaluated
         iters : int
-            number of iterations
+            number of iterations. Default is :code:`1000`
         n_processes : int
             number of processes to use for parallel particle evaluation
             Default is None with no parallelization

--- a/pyswarms/base/base_single.py
+++ b/pyswarms/base/base_single.py
@@ -50,7 +50,7 @@ class SwarmOptimizer(abc.ABC):
         velocity_clamp=None,
         center=1.0,
         ftol=-np.inf,
-        ftol_iter=1,
+        ftol_iter=50,
         init_pos=None,
     ):
         """Initialize the swarm
@@ -82,13 +82,16 @@ class SwarmOptimizer(abc.ABC):
             sets the limits for velocity clamping.
         center : list, optional
             an array of size :code:`dimensions`
-        ftol : float, optional
-            relative error in objective_func(best_pos) acceptable for
-            convergence. Default is :code:`-np.inf`.
+        ftol : float
+            relative error in objective_func(best_pos) acceptable for convergence.
+            To deactivate it in order to process all iterations, use any negative value.
+            Deactivating ftol also disables ftol_iter.
+            Default is :code: `-np.inf` to disable ftol
         ftol_iter : int
-            number of iterations over which the relative error in
-            objective_func(best_pos) is acceptable for convergence.
-            Default is :code:`1`
+            number of consecutive iterations over which the relative change in
+            objective_func(best_pos) is stalled or less than ftol. It works
+            when ftol is greater than zero (e.g. 1e-6)
+            Default is :code:`50`
         """
         # Initialize primary swarm attributes
         self.n_particles = n_particles
@@ -144,7 +147,7 @@ class SwarmOptimizer(abc.ABC):
         self.velocity_history.append(hist.velocity)
 
     @abc.abstractmethod
-    def optimize(self, objective_func, iters, n_processes=None, **kwargs):
+    def optimize(self, objective_func, iters=1000, n_processes=None, **kwargs):
         """Optimize the swarm for a number of iterations
 
         Performs the optimization to evaluate the objective
@@ -156,7 +159,7 @@ class SwarmOptimizer(abc.ABC):
         objective_func : function
             objective function to be evaluated
         iters : int
-            number of iterations
+            number of iterations. Default is :code:`1000`
         n_processes : int
             number of processes to use for parallel particle evaluation
             Default is None with no parallelization

--- a/pyswarms/single/general_optimizer.py
+++ b/pyswarms/single/general_optimizer.py
@@ -86,7 +86,7 @@ class GeneralOptimizerPSO(SwarmOptimizer):
         vh_strategy="unmodified",
         center=1.00,
         ftol=-np.inf,
-        ftol_iter=1,
+        ftol_iter=50,
         init_pos=None,
     ):
         """Initialize the swarm
@@ -157,12 +157,15 @@ class GeneralOptimizerPSO(SwarmOptimizer):
         center : list (default is :code:`None`)
             an array of size :code:`dimensions`
         ftol : float
-            relative error in objective_func(best_pos) acceptable for
-            convergence. Default is :code:`-np.inf`
+            relative error in objective_func(best_pos) acceptable for convergence.
+            To deactivate it in order to process all iterations, use any negative value.
+            Deactivating ftol also disables ftol_iter.
+            Default is :code: `-np.inf` to disable ftol
         ftol_iter : int
-            number of iterations over which the relative error in
-            objective_func(best_pos) is acceptable for convergence.
-            Default is :code:`1`
+            number of consecutive iterations over which the relative change in
+            objective_func(best_pos) is stalled or less than ftol. It works
+            when ftol is greater than zero (e.g. 1e-6)
+            Default is :code:`50`
         init_pos : numpy.ndarray, optional
             option to explicitly set the particles' initial positions. Set to
             :code:`None` if you wish to generate the particles randomly.
@@ -195,7 +198,7 @@ class GeneralOptimizerPSO(SwarmOptimizer):
         self.name = __name__
 
     def optimize(
-        self, objective_func, iters, n_processes=None, verbose=True, **kwargs
+        self, objective_func, iters=1000, n_processes=None, verbose=True, **kwargs
     ):
         """Optimize the swarm for a number of iterations
 
@@ -207,7 +210,7 @@ class GeneralOptimizerPSO(SwarmOptimizer):
         objective_func : callable
             objective function to be evaluated
         iters : int
-            number of iterations
+            number of iterations. Default is :code:`1000`
         n_processes : int
             number of processes to use for parallel particle evaluation (default: None = no parallelization)
         verbose : bool
@@ -269,10 +272,8 @@ class GeneralOptimizerPSO(SwarmOptimizer):
                 np.abs(self.swarm.best_cost - best_cost_yet_found)
                 < relative_measure
             )
-            if i < self.ftol_iter:
-                ftol_history.append(delta)
-            else:
-                ftol_history.append(delta)
+            ftol_history.append(delta)
+            if i > self.ftol_iter:
                 if all(ftol_history):
                     break
             # Perform options update

--- a/pyswarms/single/global_best.py
+++ b/pyswarms/single/global_best.py
@@ -84,7 +84,7 @@ class GlobalBestPSO(SwarmOptimizer):
         vh_strategy="unmodified",
         center=1.00,
         ftol=-np.inf,
-        ftol_iter=1,
+        ftol_iter=50,
         init_pos=None,
     ):
         """Initialize the swarm
@@ -121,12 +121,15 @@ class GlobalBestPSO(SwarmOptimizer):
         center : list (default is :code:`None`)
             an array of size :code:`dimensions`
         ftol : float
-            relative error in objective_func(best_pos) acceptable for
-            convergence. Default is :code:`-np.inf`
+            relative error in objective_func(best_pos) acceptable for convergence.
+            To deactivate it in order to process all iterations, use any negative value.
+            Deactivating ftol also disables ftol_iter.
+            Default is :code: `-np.inf` to disable ftol
         ftol_iter : int
-            number of iterations over which the relative error in
-            objective_func(best_pos) is acceptable for convergence.
-            Default is :code:`1`
+            number of consecutive iterations over which the relative change in
+            objective_func(best_pos) is stalled or less than ftol. It works
+            when ftol is greater than zero (e.g. 1e-6)
+            Default is :code:`50`
         init_pos : numpy.ndarray, optional
             option to explicitly set the particles' initial positions. Set to
             :code:`None` if you wish to generate the particles randomly.
@@ -157,7 +160,7 @@ class GlobalBestPSO(SwarmOptimizer):
         self.name = __name__
 
     def optimize(
-        self, objective_func, iters, n_processes=None, verbose=True, **kwargs
+        self, objective_func, iters=1000, n_processes=None, verbose=True, **kwargs
     ):
         """Optimize the swarm for a number of iterations
 
@@ -169,7 +172,7 @@ class GlobalBestPSO(SwarmOptimizer):
         objective_func : callable
             objective function to be evaluated
         iters : int
-            number of iterations
+            number of iterations. Default is :code:`1000`
         n_processes : int
             number of processes to use for parallel particle evaluation (default: None = no parallelization)
         verbose : bool
@@ -229,10 +232,8 @@ class GlobalBestPSO(SwarmOptimizer):
                 np.abs(self.swarm.best_cost - best_cost_yet_found)
                 < relative_measure
             )
-            if i < self.ftol_iter:
-                ftol_history.append(delta)
-            else:
-                ftol_history.append(delta)
+            ftol_history.append(delta)
+            if i > self.ftol_iter:
                 if all(ftol_history):
                     break
             # Perform options update

--- a/pyswarms/single/local_best.py
+++ b/pyswarms/single/local_best.py
@@ -93,7 +93,7 @@ class LocalBestPSO(SwarmOptimizer):
         vh_strategy="unmodified",
         center=1.00,
         ftol=-np.inf,
-        ftol_iter=1,
+        ftol_iter=50,
         init_pos=None,
         static=False,
     ):
@@ -122,12 +122,15 @@ class LocalBestPSO(SwarmOptimizer):
         center : list, optional
             an array of size :code:`dimensions`
         ftol : float
-            relative error in objective_func(best_pos) acceptable for
-            convergence. Default is :code:`-np.inf`
+            relative error in objective_func(best_pos) acceptable for convergence.
+            To deactivate it in order to process all iterations, use any negative value.
+            Deactivating ftol also disables ftol_iter.
+            Default is :code: `-np.inf` to disable ftol
         ftol_iter : int
-            number of iterations over which the relative error in
-            objective_func(best_pos) is acceptable for convergence.
-            Default is :code:`1`
+            number of consecutive iterations over which the relative change in
+            objective_func(best_pos) is stalled or less than ftol. It works
+            when ftol is greater than zero (e.g. 1e-6)
+            Default is :code:`50`
         options : dict with keys :code:`{'c1', 'c2', 'w', 'k', 'p'}`
             a dictionary containing the parameters for the specific
             optimization technique
@@ -181,7 +184,7 @@ class LocalBestPSO(SwarmOptimizer):
         self.name = __name__
 
     def optimize(
-        self, objective_func, iters, n_processes=None, verbose=True, **kwargs
+        self, objective_func, iters=1000, n_processes=None, verbose=True, **kwargs
     ):
         """Optimize the swarm for a number of iterations
 
@@ -193,7 +196,7 @@ class LocalBestPSO(SwarmOptimizer):
         objective_func : callable
             objective function to be evaluated
         iters : int
-            number of iterations
+            number of iterations. Default is :code:`1000`
         n_processes : int
             number of processes to use for parallel particle evaluation (default: None = no parallelization)
         verbose : bool
@@ -257,10 +260,8 @@ class LocalBestPSO(SwarmOptimizer):
                 np.abs(self.swarm.best_cost - best_cost_yet_found)
                 < relative_measure
             )
-            if i < self.ftol_iter:
-                ftol_history.append(delta)
-            else:
-                ftol_history.append(delta)
+            ftol_history.append(delta)
+            if i > self.ftol_iter:
                 if all(ftol_history):
                     break
             # Perform options update


### PR DESCRIPTION
The descriptions of `ftol` and `ftol_iter` were improved. Also, the default value of `ftol_iter` was changed from 1 to 50, to avoid a premature solution. In addition, the code of `ftol_iter` was modified to make it more readable. Finally, a default value of 1000 was defined for `iters` in **optimize** method. So it can be used simply by calling `optimizer.optimize(obj_func)`.

## Description
As discussed here [(#447)](https://github.com/ljvmiranda921/pyswarms/issues/447), there was confusion in the description and purpose of using `ftol_iter`. By improving `ftol` and `ftol_iter` descriptions, and changing `ftol_iter` default value, one can use it as the `stall_iter` feature without any issue with a premature solution. 


## Motivation and Context
Confusion in understanding the purpose of ftol_iter, and its default value was resulting in a premature solution.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Updating parameters descriptions.
- [ x] Updating parameters default values.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.

