### PR TITLE
Fix reporter.py compatibility

### DIFF
--- a/pyswarms/utils/reporter/reporter.py
+++ b/pyswarms/utils/reporter/reporter.py
@@ -22,17 +22,7 @@ class Reporter(object):
         rep = Reporter()
         rep.log("Here's my message", lvl=logging.INFO)
 
-    This will set-up a reporter with a default configuration that
-    logs to a file, `report.log`, on the current working directory.
-    You can change the log path by passing a string to the `log_path`
-    parameter:
-
-    .. code-block:: python
-
-        from pyswarms.utils import Reporter
-
-        rep = Reporter(log_path="/path/to/log/file.log")
-        rep.log("Here's my message", lvl=logging.INFO)
+    This will set-up a reporter with a default logger of `__name__`.
 
     If you are working on a module and you have an existing logger,
     you can pass that logger instance during initialization:
@@ -46,31 +36,15 @@ class Reporter(object):
         logger = logging.getLogger(__name__)
         rep = Reporter(logger=logger)
 
-    Lastly, if you have your own logger configuration (YAML file),
-    then simply pass that to the `config_path` parameter. This
-    overrides the default configuration (including `log_path`):
-
-    .. code-block:: python
-
-        from pyswarms.utils import Reporter
-
-        rep = Reporter(config_path="/path/to/config/file.yml")
-        rep.log("Here's my message", lvl=logging.INFO)
-
     """
 
     def __init__(
-        self, log_path=None, config_path=None, logger=None, printer=None
+        self, logger=None, printer=None
     ):
         """Initialize the reporter
 
         Attributes
         ----------
-        log_path : str, optional
-            Sets the default log path (overriden when :code:`path` is given to
-            :code:`_setup_logger()`)
-        config_path : str, optional
-            Sets the configuration path for custom loggers
         logger : logging.Logger, optional
             The logger object. By default, it creates a new :code:`Logger`
             instance
@@ -80,42 +54,7 @@ class Reporter(object):
         """
         self.logger = logger or logging.getLogger(__name__)
         self.printer = printer or pprint.PrettyPrinter()
-        self.log_path = log_path or (os.getcwd() + "/report.log")
         self._bar_fmt = "{l_bar}{bar}|{n_fmt}/{total_fmt}{postfix}"
-        self._env_key = "LOG_CFG"
-        self._default_config = {
-            "version": 1,
-            "disable_existing_loggers": False,
-            "formatters": {
-                "standard": {
-                    "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-                }
-            },
-            "handlers": {
-                "default": {
-                    "level": "INFO",
-                    "class": "logging.StreamHandler",
-                    "formatter": "standard",
-                },
-                "file_default": {
-                    "level": "INFO",
-                    "formatter": "standard",
-                    "class": "logging.handlers.RotatingFileHandler",
-                    "filename": self.log_path,
-                    "encoding": "utf8",
-                    "maxBytes": 10485760,
-                    "backupCount": 20,
-                },
-            },
-            "loggers": {
-                "": {
-                    "handlers": ["default", "file_default"],
-                    "level": "INFO",
-                    "propagate": True,
-                }
-            },
-        }
-        self._setup_logger(config_path)
 
     def log(self, msg, lvl=logging.INFO, *args, **kwargs):
         """Log a message within a set level
@@ -160,32 +99,6 @@ class Reporter(object):
             self.printer.pprint(msg)
         else:
             pass
-
-    def _setup_logger(self, path=None):
-        """Set-up the logger with default values
-
-        This method is called right after initializing the Reporter module.
-        If no path is supplied, then it loads a default configuration.
-        You can view the defaults via the Reporter._default_config attribute.
-
-
-        Parameters
-        ----------
-        path : str, optional
-            Path to a YAML configuration. If not supplied, uses
-            a default config.
-        """
-        value = path or os.getenv(self._env_key, None)
-        try:
-            with open(value, "rt") as f:
-                config = yaml.safe_load(f.read())
-            logging.config.dictConfig(config)
-        except (TypeError, FileNotFoundError):
-            self._load_defaults()
-
-    def _load_defaults(self):
-        """Load default logging configuration"""
-        logging.config.dictConfig(self._default_config)
 
     def pbar(self, iters, desc=None):
         """Create a tqdm iterable


### PR DESCRIPTION
Removed much of Reporter so that it would no longer overwrite the root logger; however, this does mean that the end user must set up logging themselves if they wish to log to a file.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Several large chunks of reporter.py, and features of the Reporter, were removed entirely, as they tended to cause compatibility issues with anything else that wished to use logging. This means that Reporter no longer allows for a custom logger format or output file, as it seems wise to let users set this up through logging itself instead of giving a default config to the root logger.

## Related Issue
Should fix issue #462 

## Motivation and Context
The Reporter class previously contained quite a lot of code, including a custom logging format, that caused issues when used with anything with its own logging.

## How Has This Been Tested?
This could potentially use some more testing, but a quick search with grep showed that the removed methods and arguments were not used anywhere else in pyswarms, so it should not cause any issues. I have only tested it in python 3.8.5.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

