### PR TITLE
add_stylesheet -> add_css_file

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -164,7 +164,7 @@ html_static_path = ["_static"]
 
 def setup(app):
     # overrides for wide tables in RTD theme
-    app.add_stylesheet("theme_overrides.css")  # path relative to static
+    app.add_css_file("theme_overrides.css")  # path relative to static
 
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page


### PR DESCRIPTION
pyswarms documentation fails to build with the newest Sphinx stack.

Report: https://download.copr.fedorainfracloud.org/results/ksurma/pygments-2.9.0/fedora-rawhide-x86_64/02258998-python-pyswarms/build.log.gz

Problem:: Changed in version 1.8: add_stylesheet() was renamed to add_css_file() [See API documentation](https://www.sphinx-doc.org/en/master/extdev/appapi.html)