### PR TITLE
Forgetful Global Best PSO

### DIFF
--- a/pyswarms/backend/operators.py
+++ b/pyswarms/backend/operators.py
@@ -62,13 +62,12 @@ def compute_pbest(swarm):
     try:
         # Check whether swarm is forgetful
         if hasattr(swarm, 'memory'):
-            memory = swarm.memory
             swarm.recent.append(swarm.current_cost)
             swarm.recent_position.append(swarm.position)
-            new_pbest_cost = np.min(swarm.recent,0)
+            new_pbest_cost = np.min(swarm.recent, 0)
             min_index = np.argmin(swarm.recent, axis=0)
-            temp = np.array([min_index,np.arange(swarm.n_particles)]).T
-            new_pbest_pos = np.array(swarm.recent_position)[temp[:,0],temp[:,1]]
+            temp = np.array([min_index, np.arange(swarm.n_particles)]).T
+            new_pbest_pos = np.array(swarm.recent_position)[temp[:, 0], temp[:, 1]]
         else:
             # Infer dimensions from positions
             dimensions = swarm.dimensions

--- a/pyswarms/single/global_best.py
+++ b/pyswarms/single/global_best.py
@@ -216,7 +216,15 @@ class GlobalBestPSO(SwarmOptimizer):
             self.swarm.pbest_pos, self.swarm.pbest_cost = compute_pbest(self.swarm)
             # Set best_cost_yet_found for ftol
             best_cost_yet_found = self.swarm.best_cost
-            self.swarm.best_pos, self.swarm.best_cost = self.top.compute_gbest(self.swarm)
+            # Check for forgetfulness as needed
+            if memory is not None:
+                # Currently, topologies don't look at recent and recent_position, so we
+                # do this manually.
+                global_best_in_memory = np.min(self.swarm.pbest_cost)
+                self.swarm.best_cost = global_best_in_memory
+                self.swarm.best_pos = self.swarm.pbest_pos[np.argmin(self.swarm.pbest_cost)]
+            else:
+                self.swarm.best_pos, self.swarm.best_cost = self.top.compute_gbest(self.swarm)
             # fmt: on
             if verbose:
                 self.rep.hook(best_cost=self.swarm.best_cost)
@@ -254,9 +262,7 @@ class GlobalBestPSO(SwarmOptimizer):
             )
         # Obtain the final best_cost and the final best_position
         final_best_cost = self.swarm.best_cost.copy()
-        final_best_pos = self.swarm.pbest_pos[
-            self.swarm.pbest_cost.argmin()
-        ].copy()
+        final_best_pos = self.swarm.best_pos.copy()
         # Write report in log and return final cost and position
         self.rep.log(
             "Optimization finished | best cost: {}, best pos: {}".format(

--- a/pyswarms/single/global_best.py
+++ b/pyswarms/single/global_best.py
@@ -157,7 +157,7 @@ class GlobalBestPSO(SwarmOptimizer):
         self.name = __name__
 
     def optimize(
-        self, objective_func, iters, memory = None, n_processes=None, verbose=True, **kwargs
+        self, objective_func, iters, memory=None, n_processes=None, verbose=True, **kwargs
     ):
         """Optimize the swarm for a number of iterations
 
@@ -206,8 +206,8 @@ class GlobalBestPSO(SwarmOptimizer):
         self.swarm.pbest_cost = np.full(self.swarm_size[0], np.inf)
         if memory is not None:
             self.swarm.memory = memory
-            self.swarm.recent = deque(np.full((memory,self.swarm_size[0]), np.inf),memory)
-            self.swarm.recent_position = deque(np.full((memory,self.swarm_size[0],self.swarm.dimensions), np.inf),memory)
+            self.swarm.recent = deque(np.full((memory, self.swarm_size[0]), np.inf), memory)
+            self.swarm.recent_position = deque(np.full((memory, self.swarm_size[0], self.swarm.dimensions), np.inf), memory)
         ftol_history = deque(maxlen=self.ftol_iter)
         for i in self.rep.pbar(iters, self.name) if verbose else range(iters):
             # Compute cost for current position and personal best

--- a/pyswarms/single/global_best.py
+++ b/pyswarms/single/global_best.py
@@ -157,7 +157,7 @@ class GlobalBestPSO(SwarmOptimizer):
         self.name = __name__
 
     def optimize(
-        self, objective_func, iters, n_processes=None, verbose=True, **kwargs
+        self, objective_func, iters, memory = None, n_processes=None, verbose=True, **kwargs
     ):
         """Optimize the swarm for a number of iterations
 
@@ -170,6 +170,8 @@ class GlobalBestPSO(SwarmOptimizer):
             objective function to be evaluated
         iters : int
             number of iterations
+        memory : int
+            number of iterations to keep a global best value for before discarding (default: None = never discard)
         n_processes : int
             number of processes to use for parallel particle evaluation (default: None = no parallelization)
         verbose : bool
@@ -202,6 +204,10 @@ class GlobalBestPSO(SwarmOptimizer):
         pool = None if n_processes is None else mp.Pool(n_processes)
 
         self.swarm.pbest_cost = np.full(self.swarm_size[0], np.inf)
+        if memory is not None:
+            self.swarm.memory = memory
+            self.swarm.recent = deque(np.full((memory,self.swarm_size[0]), np.inf),memory)
+            self.swarm.recent_position = deque(np.full((memory,self.swarm_size[0],self.swarm.dimensions), np.inf),memory)
         ftol_history = deque(maxlen=self.ftol_iter)
         for i in self.rep.pbar(iters, self.name) if verbose else range(iters):
             # Compute cost for current position and personal best

--- a/tests/optimizers/test_global_best.py
+++ b/tests/optimizers/test_global_best.py
@@ -38,3 +38,31 @@ class TestGlobalBestOptimizer(ABCTestOptimizer):
         min_cost_idx = np.argmin(opt.cost_history)
         min_pos_idx = np.argmin(sphere(opt.pos_history[min_cost_idx]))
         assert np.array_equal(opt.pos_history[min_cost_idx][min_pos_idx], pos)
+
+
+class TestGlobalBestOptimizerForgetful(ABCTestOptimizer):
+    @pytest.fixture
+    def optimizer(self):
+        return GlobalBestPSO
+
+    @pytest.fixture
+    def optimizer_history(self, options):
+        opt = GlobalBestPSO(10, 2, options=options)
+        opt.optimize(sphere, 1000, memory=15)
+        return opt
+
+    @pytest.fixture
+    def optimizer_reset(self, options):
+        opt = GlobalBestPSO(10, 2, options=options)
+        opt.optimize(sphere, 10, memory=15)
+        opt.reset()
+        return opt
+
+    def test_global_correct_pos(self, options):
+        """ Test to check global optimiser returns the correct position corresponding to the best cost """
+        opt = GlobalBestPSO(n_particles=10, dimensions=2, options=options)
+        cost, pos = opt.optimize(sphere, iters=5, memory=15)
+        # find best pos from history
+        min_cost_idx = np.argmin(opt.cost_history)
+        min_pos_idx = np.argmin(sphere(opt.pos_history[min_cost_idx]))
+        assert np.array_equal(opt.pos_history[min_cost_idx][min_pos_idx], pos)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add an option for "forgetful" behavior in the global best particle swarm optimizer. If set, the "memory" parameter of the "optimize" method tells the optimizer how long to continue global best values before discarding them. It does this by keeping a fixed-size deque of recent positions and costs. The "memory" parameter is set to None by default, which disables all changes, so this should not cause any changes to existing code behavior.
<!--- Describe your changes in detail -->

## Related Issue
See Issue #465 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
When using a particle swarm as an optimizer, the global best pso is confused by noisy data. A single particularly high, and noisy, data point can persist and cause issues for the rest of the optimization. This change fixes this issue, allowing global best values to be forgotten after some length of time.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
The test suite, with new tests for the new feature, runs without issue.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

