### PR TITLE
Add invalid swarm.best_pos check (#475)

### DIFF
--- a/pyswarms/backend/operators.py
+++ b/pyswarms/backend/operators.py
@@ -134,11 +134,18 @@ def compute_velocity(swarm, clamp, vh, bounds=None):
             * np.random.uniform(0, 1, swarm_size)
             * (swarm.pbest_pos - swarm.position)
         )
-        social = (
-            c2
-            * np.random.uniform(0, 1, swarm_size)
-            * (swarm.best_pos - swarm.position)
-        )
+        if swarm.best_pos.shape != (0,):
+            social = (
+                c2
+                * np.random.uniform(0, 1, swarm_size)
+                * (swarm.best_pos - swarm.position)
+            )
+        else:
+            social = (
+                c2
+                * np.random.uniform(0, 1, swarm_size)
+                * (swarm.pbest_pos - swarm.position)
+            )
         # Compute temp velocity (subject to clamping if possible)
         temp_velocity = (w * swarm.velocity) + cognitive + social
         updated_velocity = vh(

--- a/pyswarms/backend/swarms.py
+++ b/pyswarms/backend/swarms.py
@@ -100,7 +100,7 @@ class Swarm(object):
         validator=instance_of(np.ndarray),
     )
     best_cost = attrib(
-        type=float, default=np.inf, validator=instance_of((int, float))
+        type=float, default=np.float64(np.inf), validator=instance_of((int, float))
     )
     current_cost = attrib(
         type=np.ndarray,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds both a check whether swarm.best_pos has a shape of 0, as well as changing the default initial value of swarm.best_cost from a float to a np.float64 so that no issues arise when copy() is called on it without it having been modified.
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes Issue #475 

## Motivation and Context
As seen in the linked issue, the optimizers tend to have issues with cost functions that can return np.inf or np.nan. Most of the time, this won't cause any issues, but a cost function could potentially be designed that returns either np.inf or np.nan in large sections of its domain - for instance, a cost function that returns np.inf or np.nan for "out of bounds" values. Additionally, if the algorithm finishes running without swarm.best_cost having been modified, it will attempt to call copy() on np.inf, which is of type float. This was fixed by replacing np.inf with np.float64(np.inf) as the default best_cost value.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
The example code provided in issue #475 was tested to confirm that this does indeed fix the bug, and the standard test suite was run and all passed.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

