### PR TITLE
Specify Sphinx version >=1.8,<2 in dev dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -67,7 +67,7 @@ seaborn==0.9.0
 six==1.12.0
 snowballstemmer==1.2.1
 sphinx-rtd-theme==0.4.3
-sphinx==1.7.6
+sphinx>=1.8,<2
 sphinxcontrib-napoleon==0.7
 sphinxcontrib-websupport==1.1.0
 testpath==0.4.2


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Docs aren't built successfully by Read The Docs because Sphinx is pinned to v1.7.6 in `requirements-dev.txt`, but https://github.com/ljvmiranda921/pyswarms/pull/468 introduced a doc change which requires Sphinx v1.8 or newer. This PR updates the Sphinx version to `>=1.8,<2` in `requirements-dev.txt` so that the docs can hopefully be built successfully.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
No open issues address that the docs fail, but this issue e.g. #389 cannot go on unless this is fixed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We depend on PySwarms in PyEBSDIndex (https://github.com/USNavalResearchLaboratory/PyEBSDIndex) and would like for our dependencies to have an up-to-date documentation for our users to read.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On Ubuntu 22.04.

Not tested, since I tried building the docs myself but got this error:

```bash
$ conda create -n ps-env python=3.9
$ conda activate ps-env
$ python setup.py develop
$ pip install 'sphinx>=1.8,<2'
$ cd docs
$ make html
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v1.8.6

Extension error:
Could not import extension sphinx.builders.latex (exception: cannot import name 'contextfunction' from 'jinja2' (/home/hakon/miniconda3/envs/ps-env/lib/python3.9/site-packages/jinja2/__init__.py))
make: *** [Makefile:53: html] Error 2
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [n/a] My code follows the code style of this project.
- [n/a] My change requires a change to the documentation.
- [n/a] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [n/a] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

