### PR TITLE
Implemented options to hotstart training

### DIFF
--- a/pyswarms/backend/generators.py
+++ b/pyswarms/backend/generators.py
@@ -22,7 +22,7 @@ rep = Reporter(logger=logging.getLogger(__name__))
 
 
 def generate_swarm(
-    n_particles, dimensions, bounds=None, center=1.00, init_pos=None
+    n_particles, dimensions, bounds=None, center=1.00, init_pos=None, init_best=None
 ):
     """Generate a swarm
 
@@ -41,6 +41,10 @@ def generate_swarm(
         Default is :code:`1`
     init_pos : numpy.ndarray, optional
         option to explicitly set the particles' initial positions. Set to
+        :code:`None` if you wish to generate the particles randomly.
+        Default is :code:`None`.
+    init_best : numpy.ndarray, optional
+        option to explicitly set a particle to the previously obtained global best. Set to
         :code:`None` if you wish to generate the particles randomly.
         Default is :code:`None`.
 
@@ -81,6 +85,8 @@ def generate_swarm(
             pos = center * np.random.uniform(
                 low=min_bounds, high=max_bounds, size=(n_particles, dimensions)
             )
+        if init_best is not None: 
+            pos[0] = init_best 
     except ValueError:
         msg = "Bounds and/or init_pos should be of size ({},)"
         rep.logger.exception(msg.format(dimensions))
@@ -193,6 +199,8 @@ def create_swarm(
     bounds=None,
     center=1.0,
     init_pos=None,
+    init_vel=None,
+    init_best=None,
     clamp=None,
 ):
     """Abstract the generate_swarm() and generate_velocity() methods
@@ -218,6 +226,12 @@ def create_swarm(
     init_pos : numpy.ndarray, optional
         option to explicitly set the particles' initial positions. Set to
         :code:`None` if you wish to generate the particles randomly.
+    init_vel : numpy.ndarray, optional
+        option to explicitly set the particles' initial velocities. Set to
+        :code:`None` if you wish to generate the velocities randomly.
+    init_best : numpy.ndarray, optional
+        option to explicitly set a particle to the previously obtained global best. Set to
+        :code:`None` if you wish to generate the particles randomly.
     clamp : tuple of floats, optional
         a tuple of size 2 where the first entry is the minimum velocity
         and the second entry is the maximum velocity. It
@@ -230,7 +244,7 @@ def create_swarm(
     """
     if discrete:
         position = generate_discrete_swarm(
-            n_particles, dimensions, binary=binary, init_pos=init_pos
+            n_particles, dimensions, binary=binary, init_pos=init_pos # TODO add init_best 
         )
     else:
         position = generate_swarm(
@@ -239,7 +253,11 @@ def create_swarm(
             bounds=bounds,
             center=center,
             init_pos=init_pos,
+            init_best=init_best,
         )
 
-    velocity = generate_velocity(n_particles, dimensions, clamp=clamp)
+    if init_vel is None:
+        velocity = generate_velocity(n_particles, dimensions, clamp=clamp)
+    else: 
+        velocity = init_vel 
     return Swarm(position, velocity, options=options)

--- a/pyswarms/base/base_discrete.py
+++ b/pyswarms/base/base_discrete.py
@@ -48,6 +48,8 @@ class DiscreteSwarmOptimizer(abc.ABC):
         options,
         velocity_clamp=None,
         init_pos=None,
+        init_vel=None,
+        init_best=None,
         ftol=-np.inf,
         ftol_iter=1,
     ):
@@ -81,6 +83,15 @@ class DiscreteSwarmOptimizer(abc.ABC):
             a tuple of size 2 where the first entry is the minimum velocity
             and the second entry is the maximum velocity. It
             sets the limits for velocity clamping.
+        init_pos : numpy.ndarray, optional
+            option to explicitly set the particles' initial positions. Set to
+            :code:`None` if you wish to generate the particles randomly.
+        init_vel : numpy.ndarray, optional
+            option to explicitly set the particles' initial velocities. Set to
+            :code:`None` if you wish to generate the velocities randomly.
+        init_best : numpy.ndarray, optional
+            option to explicitly set a particle to the previously obtained global best. Set to
+            :code:`None` if you wish to generate the particles randomly.
         ftol : float, optional
             relative error in objective_func(best_pos) acceptable for
             convergence. Default is :code:`-np.inf`.
@@ -100,6 +111,8 @@ class DiscreteSwarmOptimizer(abc.ABC):
         self.swarm_size = (n_particles, dimensions)
         self.options = options
         self.init_pos = init_pos
+        self.init_vel = init_vel
+        self.init_best = init_best 
         self.ftol = ftol
 
         try:
@@ -208,6 +221,8 @@ class DiscreteSwarmOptimizer(abc.ABC):
             dimensions=self.dimensions,
             discrete=True,
             init_pos=self.init_pos,
+            init_vel=self.init_vel,
+            init_best=self.init_best,
             binary=self.binary,
             clamp=self.velocity_clamp,
             options=self.options,

--- a/pyswarms/base/base_single.py
+++ b/pyswarms/base/base_single.py
@@ -52,6 +52,8 @@ class SwarmOptimizer(abc.ABC):
         ftol=-np.inf,
         ftol_iter=1,
         init_pos=None,
+        init_vel=None,
+        init_best=None,
     ):
         """Initialize the swarm
 
@@ -89,6 +91,15 @@ class SwarmOptimizer(abc.ABC):
             number of iterations over which the relative error in
             objective_func(best_pos) is acceptable for convergence.
             Default is :code:`1`
+        init_pos : numpy.ndarray, optional
+            option to explicitly set the particles' initial positions. Set to
+            :code:`None` if you wish to generate the particles randomly.
+        init_vel : numpy.ndarray, optional
+            option to explicitly set the particles' initial velocities. Set to
+            :code:`None` if you wish to generate the velocities randomly.
+        init_best : numpy.ndarray, optional
+            option to explicitly set a particle to the previously obtained global best. Set to
+            :code:`None` if you wish to generate the particles randomly.
         """
         # Initialize primary swarm attributes
         self.n_particles = n_particles
@@ -109,6 +120,8 @@ class SwarmOptimizer(abc.ABC):
 
         self.ftol_iter = ftol_iter
         self.init_pos = init_pos
+        self.init_vel = init_vel
+        self.init_best = init_best 
         # Initialize named tuple for populating the history list
         self.ToHistory = namedtuple(
             "ToHistory",
@@ -207,6 +220,8 @@ class SwarmOptimizer(abc.ABC):
             bounds=self.bounds,
             center=self.center,
             init_pos=self.init_pos,
+            init_vel=self.init_vel,
+            init_best=self.init_best,
             clamp=self.velocity_clamp,
             options=self.options,
         )

--- a/pyswarms/single/general_optimizer.py
+++ b/pyswarms/single/general_optimizer.py
@@ -88,6 +88,8 @@ class GeneralOptimizerPSO(SwarmOptimizer):
         ftol=-np.inf,
         ftol_iter=1,
         init_pos=None,
+        init_vel=None,
+        init_best=None,
     ):
         """Initialize the swarm
 
@@ -166,6 +168,12 @@ class GeneralOptimizerPSO(SwarmOptimizer):
         init_pos : numpy.ndarray, optional
             option to explicitly set the particles' initial positions. Set to
             :code:`None` if you wish to generate the particles randomly.
+        init_vel : numpy.ndarray, optional
+            option to explicitly set the particles' initial velocities. Set to
+            :code:`None` if you wish to generate the velocities randomly.
+        init_best : numpy.ndarray, optional
+            option to explicitly set a particle to the previously obtained global best. Set to
+            :code:`None` if you wish to generate the particles randomly.
         """
         super(GeneralOptimizerPSO, self).__init__(
             n_particles,
@@ -177,6 +185,8 @@ class GeneralOptimizerPSO(SwarmOptimizer):
             ftol=ftol,
             ftol_iter=ftol_iter,
             init_pos=init_pos,
+            init_vel=init_vel,
+            init_best=init_best,
         )
         if oh_strategy is None:
             oh_strategy = {}

--- a/pyswarms/single/global_best.py
+++ b/pyswarms/single/global_best.py
@@ -86,6 +86,8 @@ class GlobalBestPSO(SwarmOptimizer):
         ftol=-np.inf,
         ftol_iter=1,
         init_pos=None,
+        init_vel=None,
+        init_best=None,
     ):
         """Initialize the swarm
 
@@ -130,6 +132,12 @@ class GlobalBestPSO(SwarmOptimizer):
         init_pos : numpy.ndarray, optional
             option to explicitly set the particles' initial positions. Set to
             :code:`None` if you wish to generate the particles randomly.
+        init_vel : numpy.ndarray, optional
+            option to explicitly set the particles' initial velocities. Set to
+            :code:`None` if you wish to generate the velocities randomly.
+        init_best : numpy.ndarray, optional
+            option to explicitly set a particle to the previously obtained global best. Set to
+            :code:`None` if you wish to generate the particles randomly.
         """
         super(GlobalBestPSO, self).__init__(
             n_particles=n_particles,
@@ -141,6 +149,8 @@ class GlobalBestPSO(SwarmOptimizer):
             ftol=ftol,
             ftol_iter=ftol_iter,
             init_pos=init_pos,
+            init_vel=init_vel,
+            init_best=init_best,
         )
 
         if oh_strategy is None:

--- a/pyswarms/single/local_best.py
+++ b/pyswarms/single/local_best.py
@@ -95,6 +95,8 @@ class LocalBestPSO(SwarmOptimizer):
         ftol=-np.inf,
         ftol_iter=1,
         init_pos=None,
+        init_vel=None,
+        init_best=None,
         static=False,
     ):
         """Initialize the swarm
@@ -147,6 +149,12 @@ class LocalBestPSO(SwarmOptimizer):
         init_pos : numpy.ndarray, optional
             option to explicitly set the particles' initial positions. Set to
             :code:`None` if you wish to generate the particles randomly.
+        init_vel : numpy.ndarray, optional
+            option to explicitly set the particles' initial velocities. Set to
+            :code:`None` if you wish to generate the velocities randomly.
+        init_best : numpy.ndarray, optional
+            option to explicitly set a particle to the previously obtained global best. Set to
+            :code:`None` if you wish to generate the particles randomly.
         static: bool
             a boolean that decides whether the Ring topology
             used is static or dynamic. Default is `False`
@@ -168,6 +176,8 @@ class LocalBestPSO(SwarmOptimizer):
             ftol=ftol,
             ftol_iter=ftol_iter,
             init_pos=init_pos,
+            init_vel=init_vel,
+            init_best=init_best,
         )
         # Initialize logger
         self.rep = Reporter(logger=logging.getLogger(__name__))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR implements an option to provide the swarm position, velocity and global best (or any particle) to the optimizer. This was performed by adding the following optional arguments to the optimizer class:
- `init_vel`
- `init_best`

The arguments were added to `GlobalBestPSO`, `GeneralOptimizerPSO` and `LocalBestPSO` as well as to the abstract base classes `SwarmOptimizer` and `DiscreteSwarmOptimizer`. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
The current implementation does not allow to properly resume a previous optimization process. This PR makes it possible while maintaining full compatibility with previous versions. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested in a limited manner so far. Only using `GlobalBestPSO` on Ubuntu 18.04, python 3.6. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly (modified docstrings in the code).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

