### PR TITLE
Fix tests with Matplotlib 3.7

### DIFF
--- a/tests/utils/plotters/test_plotters.py
+++ b/tests/utils/plotters/test_plotters.py
@@ -14,7 +14,7 @@ if os.environ.get("DISPLAY", "") == "":
     mpl.use("Agg")
 
 from matplotlib.animation import FuncAnimation
-from matplotlib.axes._subplots import SubplotBase
+from matplotlib.axes import SubplotBase
 
 # Import from pyswarms
 from pyswarms.utils.plotters import (


### PR DESCRIPTION
## Description
`SubplotBase` is available in `matplotlib.axes`; there's no need to use the private path.

## Related Issue
Fixes #508 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Ran tests with Matplotlib 3.7 and 3.6.3.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.