### PR TITLE
pbcost default values set to inf

### DIFF
--- a/docs/examples/tutorials/custom_optimization_loop.ipynb
+++ b/docs/examples/tutorials/custom_optimization_loop.ipynb
@@ -111,13 +111,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Iteration: 1 | my_swarm.best_cost: 0.0009\n",
+      "Iteration: 1 | my_swarm.best_cost: 0.0070\n",
       "Iteration: 21 | my_swarm.best_cost: 0.0000\n",
       "Iteration: 41 | my_swarm.best_cost: 0.0000\n",
       "Iteration: 61 | my_swarm.best_cost: 0.0000\n",
       "Iteration: 81 | my_swarm.best_cost: 0.0000\n",
       "The best cost found by our swarm is: 0.0000\n",
-      "The best position found by our swarm is: [3.30572365e-19 2.93696483e-19]\n"
+      "The best position found by our swarm is: [1.77943664e-18 2.49653561e-18]\n"
      ]
     }
    ],
@@ -126,7 +126,6 @@
     "for i in range(iterations):\n",
     "    # Part 1: Update personal best\n",
     "    my_swarm.current_cost = f(my_swarm.position) # Compute current cost\n",
-    "    my_swarm.pbest_cost = f(my_swarm.pbest_pos)  # Compute personal best pos\n",
     "    my_swarm.pbest_pos, my_swarm.pbest_cost = P.compute_pbest(my_swarm) # Update and store\n",
     "    \n",
     "    # Part 2: Update global best\n",
@@ -163,15 +162,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2019-05-18 15:39:20,737 - pyswarms.single.global_best - INFO - Optimize for 100 iters with {'c1': 0.6, 'c2': 0.3, 'w': 0.4}\n",
-      "pyswarms.single.global_best: 100%|██████████|100/100, best_cost=0.00418\n",
-      "2019-05-18 15:39:21,942 - pyswarms.single.global_best - INFO - Optimization finished | best cost: 0.004177699645933291, best pos: [0.03663518 0.05325001]\n"
+      "2023-10-20 14:44:14,240 - pyswarms.single.global_best - INFO - Optimize for 100 iters with {'c1': 0.6, 'c2': 0.3, 'w': 0.4}\n",
+      "pyswarms.single.global_best: 100%|██████████|100/100, best_cost=0.00596\n",
+      "2023-10-20 14:44:14,358 - pyswarms.single.global_best - INFO - Optimization finished | best cost: 0.0059581279236955356, best pos: [0.04219012 0.06463839]\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "(0.004177699645933291, array([0.03663518, 0.05325001]))"
+       "(0.0059581279236955356, array([0.04219012, 0.06463839]))"
       ]
      },
      "execution_count": 4,

--- a/pyswarms/backend/swarms.py
+++ b/pyswarms/backend/swarms.py
@@ -96,7 +96,6 @@ class Swarm(object):
     )
     pbest_cost = attrib(
         type=np.ndarray,
-        default=np.array([]),
         validator=instance_of(np.ndarray),
     )
     best_cost = attrib(
@@ -119,3 +118,7 @@ class Swarm(object):
     @pbest_pos.default
     def pbest_pos_default(self):
         return self.position
+    
+    @pbest_cost.default
+    def pbest_cost_default(self):
+        return np.full(shape=(self.position.shape[0],), fill_value=np.inf)


### PR DESCRIPTION
In the custom loop example, the objective function is called twice, which is a problem for computationally expensive objective functions, only because the array of personal best did not have default values for the first iteration. This has been fixed by setting the default values of pbcost to inf.


## Description

- The second call of the objective function in the [custom loop example](docs/examples/tutorials/custom_optimization_loop.ipynb) has been deleted.

- In the definition of the Swarm class in [swarms.py](pyswarms/backend/swarms.py), a default value setter has been defined for self.pbcost attribute.


## Motivation and Context
Without a default value for my_swar.pbcost the compute_pbcost function would raise an error in the first iteration, as there is nothing to compare the current cost to. To avoid this error, the objective function was previously called twice in the custom loop example, and not just at the first iteration but at every iteration. This almost doubles runtime, which is a major problem for computationally expensive objective functions. To resolve this issue, the default value of swarm.pbcost has been set to np.inf, to ensure it will be overwritten in the first iteration.

## How Has This Been Tested?
One can successfully run all of the example files after the change.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

