### PR TITLE
Typo Error in Documentation: Incorrect Hyperlink in Launching Pad Sec…

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,7 +42,7 @@ interaction with swarm optimizations. Check out more features below!
 Launching pad
 -------------
 
-* If you don't know what Particle Swarm Optimization is, read up this short `Introduction <http://pyswarms.readthedocs.io/en/latest/intro.html>`_! Then, if you plan to use PySwarms in your project, check the `Installation guide <https://pyswarms.readthedocs.io/en/latest/installation.html>`_ and `use-case examples <https://pyswarms.readthedocs.io/en/latest/examples/usecases.html>`_.
+* If you don't know what Particle Swarm Optimization is, read up this short `Introduction <http://pyswarms.readthedocs.io/en/latest/intro.html>`_! Then, if you plan to use PySwarms in your project, check the `Installation guide <https://pyswarms.readthedocs.io/en/latest/installation.html>`_ and `use-case examples <https://pyswarms.readthedocs.io/en/latest/usecases.html>`_.
 
 * If you are a researcher in the field of swarm intelligence, and would like to include your technique in our list of optimizers, check our `contributing <https://pyswarms.readthedocs.io/en/latest/contributing.html>`_ page to see how to implement your optimizer using the current base classes in the library.
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I found a typo in the documentation listed on the main page (https://pyswarms.readthedocs.io/en/latest/) under the Launching Pad section. The hyperlink provided to `use-cases examples` is incorrect.

## Related Issue
Fixes #524

## Motivation and Context
Just fixing a typo in the landing page of the documentation to try out use cases.

## How Has This Been Tested?
Removed the `examples` from the hyperlink and the webpage redirects to use cases correctly.

## Screenshots (if appropriate):
![Error_404_Page](https://github.com/ljvmiranda921/pyswarms/assets/57552973/678fc877-9ca1-479d-8695-4cc6694b7a83)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. --> <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.